### PR TITLE
Suppress UpdateInstance API from being executed unnecessarily

### DIFF
--- a/pkg/controllers/spannerautoscaler_controller.go
+++ b/pkg/controllers/spannerautoscaler_controller.go
@@ -288,6 +288,14 @@ func (r *SpannerAutoscalerReconciler) needUpdateNodes(sa *spannerv1alpha1.Spanne
 		log.V(0).Info("the desired number of nodes is equal to that of the current; no need to scale nodes")
 		return false
 
+	case desiredNodes > *sa.Status.CurrentNodes && r.clock.Now().Before(sa.Status.LastScaleTime.Time.Add(10*time.Second)):
+		log.Info("too short to scale up since instance scaled nodes last",
+			"now", r.clock.Now().String(),
+			"last scale time", sa.Status.LastScaleTime,
+		)
+
+		return false
+
 	case desiredNodes < *sa.Status.CurrentNodes && r.clock.Now().Before(sa.Status.LastScaleTime.Time.Add(r.scaleDownInterval)):
 		log.Info("too short to scale down since instance scaled nodes last",
 			"now", r.clock.Now().String(),

--- a/pkg/controllers/spannerautoscaler_controller.go
+++ b/pkg/controllers/spannerautoscaler_controller.go
@@ -207,7 +207,9 @@ func (r *SpannerAutoscalerReconciler) Reconcile(req ctrlreconcile.Request) (ctrl
 		*sa.Spec.MaxScaleDownNodes,
 	)
 
-	if !r.needUpdateNodes(&sa, desiredNodes) {
+	now := r.clock.Now()
+
+	if !r.needUpdateNodes(&sa, desiredNodes, now) {
 		return ctrlreconcile.Result{}, nil
 	}
 
@@ -223,7 +225,7 @@ func (r *SpannerAutoscalerReconciler) Reconcile(req ctrlreconcile.Request) (ctrl
 
 	saCopy := sa.DeepCopy()
 	saCopy.Status.DesiredNodes = &desiredNodes
-	saCopy.Status.LastScaleTime = &metav1.Time{Time: r.clock.Now()}
+	saCopy.Status.LastScaleTime = &metav1.Time{Time: now}
 
 	if err = r.ctrlClient.Status().Update(ctx, saCopy); err != nil {
 		r.recoder.Event(&sa, corev1.EventTypeWarning, "FailedUpdateStatus", err.Error())
@@ -280,7 +282,7 @@ func (r *SpannerAutoscalerReconciler) needCalcNodes(sa *spannerv1alpha1.SpannerA
 	}
 }
 
-func (r *SpannerAutoscalerReconciler) needUpdateNodes(sa *spannerv1alpha1.SpannerAutoscaler, desiredNodes int32) bool {
+func (r *SpannerAutoscalerReconciler) needUpdateNodes(sa *spannerv1alpha1.SpannerAutoscaler, desiredNodes int32, now time.Time) bool {
 	log := r.log
 
 	switch {
@@ -290,7 +292,7 @@ func (r *SpannerAutoscalerReconciler) needUpdateNodes(sa *spannerv1alpha1.Spanne
 
 	case desiredNodes > *sa.Status.CurrentNodes && r.clock.Now().Before(sa.Status.LastScaleTime.Time.Add(10*time.Second)):
 		log.Info("too short to scale up since instance scaled nodes last",
-			"now", r.clock.Now().String(),
+			"now", now.String(),
 			"last scale time", sa.Status.LastScaleTime,
 		)
 
@@ -298,7 +300,7 @@ func (r *SpannerAutoscalerReconciler) needUpdateNodes(sa *spannerv1alpha1.Spanne
 
 	case desiredNodes < *sa.Status.CurrentNodes && r.clock.Now().Before(sa.Status.LastScaleTime.Time.Add(r.scaleDownInterval)):
 		log.Info("too short to scale down since instance scaled nodes last",
-			"now", r.clock.Now().String(),
+			"now", now.String(),
 			"last scale time", sa.Status.LastScaleTime,
 		)
 

--- a/pkg/controllers/spannerautoscaler_controller_test.go
+++ b/pkg/controllers/spannerautoscaler_controller_test.go
@@ -309,7 +309,7 @@ func TestSpannerAutoscalerReconciler_needUpdateNodes(t *testing.T) {
 				clock:             clock.NewFakeClock(fakeTime),
 				log:               zapr.NewLogger(zap.NewNop()),
 			}
-			got := r.needUpdateNodes(tt.args.sa, *tt.args.sa.Status.DesiredNodes)
+			got := r.needUpdateNodes(tt.args.sa, *tt.args.sa.Status.DesiredNodes, fakeTime)
 			if got != tt.want {
 				t.Errorf("needUpdateNodes() got = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
<!--
    Please read the CLA carefully before submitting your contribution to Mercari.
    Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
    https://www.mercari.com/cla/
-->

## What this PR does / Why we need it

It will take a few seconds to execute Cloud Spanner Update Instance API and changes take effect.
This causes the Cloud Spanner Update Instance API to execute many times until the changes take effect, as shown below:

<detail>

```
2020-06-09T00:03:32.434Z	INFO	controllers.spannerautoscaler	updated nodes via google cloud api	{"namespaced name": "spanner-autoscaler/spannerautoscaler-sample", "before": 1, "after": 5}
2020-06-09T00:03:32.434Z	DEBUG	controller-runtime.manager.events	Normal	{"object": {"kind":"SpannerAutoscaler","namespace":"spanner-autoscaler","name":"spannerautoscaler-sample","uid":"995dd40f-a9e1-11ea-8797-42010a920105","apiVersion":"spanner.mercari.com/v1alpha1","resourceVersion":"14404"}, "reason": "Updated", "message": "Updated number of nodes from 1 to 5"}
2020-06-09T00:03:32.445Z	DEBUG	controller-runtime.controller	Successfully Reconciled	{"controller": "spannerautoscaler", "request": "spanner-autoscaler/spannerautoscaler-sample"}
2020-06-09T00:03:32.446Z	DEBUG	controllers.spannerautoscaler	resource status	{"namespaced name": "spanner-autoscaler/spannerautoscaler-sample", "spannerautoscaler": {"kind":"SpannerAutoscaler","apiVersion":"spanner.mercari.com/v1alpha1","metadata":{"name":"spannerautoscaler-sample","namespace":"spanner-autoscaler","selfLink":"/apis/spanner.mercari.com/v1alpha1/namespaces/spanner-autoscaler/spannerautoscalers/spannerautoscaler-sample","uid":"995dd40f-a9e1-11ea-8797-42010a920105","resourceVersion":"14409","generation":2,"creationTimestamp":"2020-06-08T23:41:39Z","annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"spanner.mercari.com/v1alpha1\",\"kind\":\"SpannerAutoscaler\",\"metadata\":{\"annotations\":{},\"name\":\"spannerautoscaler-sample\",\"namespace\":\"spanner-autoscaler\"},\"spec\":{\"maxNodes\":5,\"maxScaleDownNodes\":5,\"minNodes\":1,\"scaleTargetRef\":{\"instanceId\":\"spanner-autoscaler\",\"projectId\":\"my-project\"},\"serviceAccountSecretRef\":{\"key\":\"service-account\",\"name\":\"spanner-autoscaler-service-account\",\"namespace\":\"spanner-autoscaler\"},\"targetCPUUtilization\":{\"highPriority\":10}}}\n"}},"spec":{"scaleTargetRef":{"projectId":"my-project","instanceId":"spanner-autoscaler"},"serviceAccountSecretRef":{"name":"spanner-autoscaler-service-account","namespace":"spanner-autoscaler","key":"service-account"},"minNodes":1,"maxNodes":5,"maxScaleDownNodes":5,"targetCPUUtilization":{"highPriority":10}},"status":{"lastScaleTime":"2020-06-09T00:03:32Z","lastSyncTime":"2020-06-09T00:03:30Z","currentNodes":1,"desiredNodes":5,"instanceState":"ready","currentHighPriorityCPUUtilization":99}}}
2020-06-09T00:03:33.391Z	INFO	controllers.spannerautoscaler	updated nodes via google cloud api	{"namespaced name": "spanner-autoscaler/spannerautoscaler-sample", "before": 1, "after": 5}
2020-06-09T00:03:33.391Z	DEBUG	controller-runtime.manager.events	Normal	{"object": {"kind":"SpannerAutoscaler","namespace":"spanner-autoscaler","name":"spannerautoscaler-sample","uid":"995dd40f-a9e1-11ea-8797-42010a920105","apiVersion":"spanner.mercari.com/v1alpha1","resourceVersion":"14409"}, "reason": "Updated", "message": "Updated number of nodes from 1 to 5"}
2020-06-09T00:03:33.436Z	DEBUG	controller-runtime.controller	Successfully Reconciled	{"controller": "spannerautoscaler", "request": "spanner-autoscaler/spannerautoscaler-sample"}
2020-06-09T00:03:33.437Z	DEBUG	controllers.spannerautoscaler	resource status	{"namespaced name": "spanner-autoscaler/spannerautoscaler-sample", "spannerautoscaler": {"kind":"SpannerAutoscaler","apiVersion":"spanner.mercari.com/v1alpha1","metadata":{"name":"spannerautoscaler-sample","namespace":"spanner-autoscaler","selfLink":"/apis/spanner.mercari.com/v1alpha1/namespaces/spanner-autoscaler/spannerautoscalers/spannerautoscaler-sample","uid":"995dd40f-a9e1-11ea-8797-42010a920105","resourceVersion":"14415","generation":2,"creationTimestamp":"2020-06-08T23:41:39Z","annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"spanner.mercari.com/v1alpha1\",\"kind\":\"SpannerAutoscaler\",\"metadata\":{\"annotations\":{},\"name\":\"spannerautoscaler-sample\",\"namespace\":\"spanner-autoscaler\"},\"spec\":{\"maxNodes\":5,\"maxScaleDownNodes\":5,\"minNodes\":1,\"scaleTargetRef\":{\"instanceId\":\"spanner-autoscaler\",\"projectId\":\"my-project\"},\"serviceAccountSecretRef\":{\"key\":\"service-account\",\"name\":\"spanner-autoscaler-service-account\",\"namespace\":\"spanner-autoscaler\"},\"targetCPUUtilization\":{\"highPriority\":10}}}\n"}},"spec":{"scaleTargetRef":{"projectId":"my-project","instanceId":"spanner-autoscaler"},"serviceAccountSecretRef":{"name":"spanner-autoscaler-service-account","namespace":"spanner-autoscaler","key":"service-account"},"minNodes":1,"maxNodes":5,"maxScaleDownNodes":5,"targetCPUUtilization":{"highPriority":10}},"status":{"lastScaleTime":"2020-06-09T00:03:33Z","lastSyncTime":"2020-06-09T00:03:30Z","currentNodes":1,"desiredNodes":5,"instanceState":"ready","currentHighPriorityCPUUtilization":99}}}
2020-06-09T00:03:34.250Z	INFO	controllers.spannerautoscaler	updated nodes via google cloud api	{"namespaced name": "spanner-autoscaler/spannerautoscaler-sample", "before": 1, "after": 5}
2020-06-09T00:03:34.251Z	DEBUG	controller-runtime.manager.events	Normal	{"object": {"kind":"SpannerAutoscaler","namespace":"spanner-autoscaler","name":"spannerautoscaler-sample","uid":"995dd40f-a9e1-11ea-8797-42010a920105","apiVersion":"spanner.mercari.com/v1alpha1","resourceVersion":"14415"}, "reason": "Updated", "message": "Updated number of nodes from 1 to 5"}
2020-06-09T00:03:34.260Z	DEBUG	controller-runtime.controller	Successfully Reconciled	{"controller": "spannerautoscaler", "request": "spanner-autoscaler/spannerautoscaler-sample"}
2020-06-09T00:03:34.261Z	DEBUG	controllers.spannerautoscaler	resource status	{"namespaced name": "spanner-autoscaler/spannerautoscaler-sample", "spannerautoscaler": {"kind":"SpannerAutoscaler","apiVersion":"spanner.mercari.com/v1alpha1","metadata":{"name":"spannerautoscaler-sample","namespace":"spanner-autoscaler","selfLink":"/apis/spanner.mercari.com/v1alpha1/namespaces/spanner-autoscaler/spannerautoscalers/spannerautoscaler-sample","uid":"995dd40f-a9e1-11ea-8797-42010a920105","resourceVersion":"14419","generation":2,"creationTimestamp":"2020-06-08T23:41:39Z","annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"spanner.mercari.com/v1alpha1\",\"kind\":\"SpannerAutoscaler\",\"metadata\":{\"annotations\":{},\"name\":\"spannerautoscaler-sample\",\"namespace\":\"spanner-autoscaler\"},\"spec\":{\"maxNodes\":5,\"maxScaleDownNodes\":5,\"minNodes\":1,\"scaleTargetRef\":{\"instanceId\":\"spanner-autoscaler\",\"projectId\":\"my-project\"},\"serviceAccountSecretRef\":{\"key\":\"service-account\",\"name\":\"spanner-autoscaler-service-account\",\"namespace\":\"spanner-autoscaler\"},\"targetCPUUtilization\":{\"highPriority\":10}}}\n"}},"spec":{"scaleTargetRef":{"projectId":"my-project","instanceId":"spanner-autoscaler"},"serviceAccountSecretRef":{"name":"spanner-autoscaler-service-account","namespace":"spanner-autoscaler","key":"service-account"},"minNodes":1,"maxNodes":5,"maxScaleDownNodes":5,"targetCPUUtilization":{"highPriority":10}},"status":{"lastScaleTime":"2020-06-09T00:03:34Z","lastSyncTime":"2020-06-09T00:03:30Z","currentNodes":1,"desiredNodes":5,"instanceState":"ready","currentHighPriorityCPUUtilization":99}}}
2020-06-09T00:03:35.220Z	INFO	controllers.spannerautoscaler	updated nodes via google cloud api	{"namespaced name": "spanner-autoscaler/spannerautoscaler-sample", "before": 1, "after": 5}
2020-06-09T00:03:35.221Z	DEBUG	controller-runtime.manager.events	Normal	{"object": {"kind":"SpannerAutoscaler","namespace":"spanner-autoscaler","name":"spannerautoscaler-sample","uid":"995dd40f-a9e1-11ea-8797-42010a920105","apiVersion":"spanner.mercari.com/v1alpha1","resourceVersion":"14419"}, "reason": "Updated", "message": "Updated number of nodes from 1 to 5"}
2020-06-09T00:03:35.236Z	DEBUG	controller-runtime.controller	Successfully Reconciled	{"controller": "spannerautoscaler", "request": "spanner-autoscaler/spannerautoscaler-sample"}
2020-06-09T00:03:35.236Z	DEBUG	controllers.spannerautoscaler	resource status	{"namespaced name": "spanner-autoscaler/spannerautoscaler-sample", "spannerautoscaler": {"kind":"SpannerAutoscaler","apiVersion":"spanner.mercari.com/v1alpha1","metadata":{"name":"spannerautoscaler-sample","namespace":"spanner-autoscaler","selfLink":"/apis/spanner.mercari.com/v1alpha1/namespaces/spanner-autoscaler/spannerautoscalers/spannerautoscaler-sample","uid":"995dd40f-a9e1-11ea-8797-42010a920105","resourceVersion":"14426","generation":2,"creationTimestamp":"2020-06-08T23:41:39Z","annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"spanner.mercari.com/v1alpha1\",\"kind\":\"SpannerAutoscaler\",\"metadata\":{\"annotations\":{},\"name\":\"spannerautoscaler-sample\",\"namespace\":\"spanner-autoscaler\"},\"spec\":{\"maxNodes\":5,\"maxScaleDownNodes\":5,\"minNodes\":1,\"scaleTargetRef\":{\"instanceId\":\"spanner-autoscaler\",\"projectId\":\"my-project\"},\"serviceAccountSecretRef\":{\"key\":\"service-account\",\"name\":\"spanner-autoscaler-service-account\",\"namespace\":\"spanner-autoscaler\"},\"targetCPUUtilization\":{\"highPriority\":10}}}\n"}},"spec":{"scaleTargetRef":{"projectId":"my-project","instanceId":"spanner-autoscaler"},"serviceAccountSecretRef":{"name":"spanner-autoscaler-service-account","namespace":"spanner-autoscaler","key":"service-account"},"minNodes":1,"maxNodes":5,"maxScaleDownNodes":5,"targetCPUUtilization":{"highPriority":10}},"status":{"lastScaleTime":"2020-06-09T00:03:35Z","lastSyncTime":"2020-06-09T00:03:30Z","currentNodes":1,"desiredNodes":5,"instanceState":"ready","currentHighPriorityCPUUtilization":99}}}
2020-06-09T00:03:36.067Z	INFO	controllers.spannerautoscaler	updated nodes via google cloud api	{"namespaced name": "spanner-autoscaler/spannerautoscaler-sample", "before": 1, "after": 5}
2020-06-09T00:03:36.068Z	DEBUG	controller-runtime.manager.events	Normal	{"object": {"kind":"SpannerAutoscaler","namespace":"spanner-autoscaler","name":"spannerautoscaler-sample","uid":"995dd40f-a9e1-11ea-8797-42010a920105","apiVersion":"spanner.mercari.com/v1alpha1","resourceVersion":"14426"}, "reason": "Updated", "message": "Updated number of nodes from 1 to 5"}
2020-06-09T00:03:36.136Z	DEBUG	controller-runtime.controller	Successfully Reconciled	{"controller": "spannerautoscaler", "request": "spanner-autoscaler/spannerautoscaler-sample"}
2020-06-09T00:03:36.136Z	DEBUG	controllers.spannerautoscaler	resource status	{"namespaced name": "spanner-autoscaler/spannerautoscaler-sample", "spannerautoscaler": {"kind":"SpannerAutoscaler","apiVersion":"spanner.mercari.com/v1alpha1","metadata":{"name":"spannerautoscaler-sample","namespace":"spanner-autoscaler","selfLink":"/apis/spanner.mercari.com/v1alpha1/namespaces/spanner-autoscaler/spannerautoscalers/spannerautoscaler-sample","uid":"995dd40f-a9e1-11ea-8797-42010a920105","resourceVersion":"14431","generation":2,"creationTimestamp":"2020-06-08T23:41:39Z","annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"spanner.mercari.com/v1alpha1\",\"kind\":\"SpannerAutoscaler\",\"metadata\":{\"annotations\":{},\"name\":\"spannerautoscaler-sample\",\"namespace\":\"spanner-autoscaler\"},\"spec\":{\"maxNodes\":5,\"maxScaleDownNodes\":5,\"minNodes\":1,\"scaleTargetRef\":{\"instanceId\":\"spanner-autoscaler\",\"projectId\":\"my-project\"},\"serviceAccountSecretRef\":{\"key\":\"service-account\",\"name\":\"spanner-autoscaler-service-account\",\"namespace\":\"spanner-autoscaler\"},\"targetCPUUtilization\":{\"highPriority\":10}}}\n"}},"spec":{"scaleTargetRef":{"projectId":"my-project","instanceId":"spanner-autoscaler"},"serviceAccountSecretRef":{"name":"spanner-autoscaler-service-account","namespace":"spanner-autoscaler","key":"service-account"},"minNodes":1,"maxNodes":5,"maxScaleDownNodes":5,"targetCPUUtilization":{"highPriority":10}},"status":{"lastScaleTime":"2020-06-09T00:03:36Z","lastSyncTime":"2020-06-09T00:03:30Z","currentNodes":1,"desiredNodes":5,"instanceState":"ready","currentHighPriorityCPUUtilization":99}}}
2020-06-09T00:03:37.159Z	INFO	controllers.spannerautoscaler	updated nodes via google cloud api	{"namespaced name": "spanner-autoscaler/spannerautoscaler-sample", "before": 1, "after": 5}
2020-06-09T00:03:37.160Z	DEBUG	controller-runtime.manager.events	Normal	{"object": {"kind":"SpannerAutoscaler","namespace":"spanner-autoscaler","name":"spannerautoscaler-sample","uid":"995dd40f-a9e1-11ea-8797-42010a920105","apiVersion":"spanner.mercari.com/v1alpha1","resourceVersion":"14431"}, "reason": "Updated", "message": "Updated number of nodes from 1 to 5"}
2020-06-09T00:03:37.167Z	DEBUG	controller-runtime.controller	Successfully Reconciled	{"controller": "spannerautoscaler", "request": "spanner-autoscaler/spannerautoscaler-sample"}
2020-06-09T00:03:37.167Z	DEBUG	controllers.spannerautoscaler	resource status	{"namespaced name": "spanner-autoscaler/spannerautoscaler-sample", "spannerautoscaler": {"kind":"SpannerAutoscaler","apiVersion":"spanner.mercari.com/v1alpha1","metadata":{"name":"spannerautoscaler-sample","namespace":"spanner-autoscaler","selfLink":"/apis/spanner.mercari.com/v1alpha1/namespaces/spanner-autoscaler/spannerautoscalers/spannerautoscaler-sample","uid":"995dd40f-a9e1-11ea-8797-42010a920105","resourceVersion":"14436","generation":2,"creationTimestamp":"2020-06-08T23:41:39Z","annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"spanner.mercari.com/v1alpha1\",\"kind\":\"SpannerAutoscaler\",\"metadata\":{\"annotations\":{},\"name\":\"spannerautoscaler-sample\",\"namespace\":\"spanner-autoscaler\"},\"spec\":{\"maxNodes\":5,\"maxScaleDownNodes\":5,\"minNodes\":1,\"scaleTargetRef\":{\"instanceId\":\"spanner-autoscaler\",\"projectId\":\"my-project\"},\"serviceAccountSecretRef\":{\"key\":\"service-account\",\"name\":\"spanner-autoscaler-service-account\",\"namespace\":\"spanner-autoscaler\"},\"targetCPUUtilization\":{\"highPriority\":10}}}\n"}},"spec":{"scaleTargetRef":{"projectId":"my-project","instanceId":"spanner-autoscaler"},"serviceAccountSecretRef":{"name":"spanner-autoscaler-service-account","namespace":"spanner-autoscaler","key":"service-account"},"minNodes":1,"maxNodes":5,"maxScaleDownNodes":5,"targetCPUUtilization":{"highPriority":10}},"status":{"lastScaleTime":"2020-06-09T00:03:37Z","lastSyncTime":"2020-06-09T00:03:30Z","currentNodes":1,"desiredNodes":5,"instanceState":"ready","currentHighPriorityCPUUtilization":99}}}
2020-06-09T00:03:37.851Z	INFO	controllers.spannerautoscaler	updated nodes via google cloud api	{"namespaced name": "spanner-autoscaler/spannerautoscaler-sample", "before": 1, "after": 5}
2020-06-09T00:03:37.851Z	DEBUG	controller-runtime.manager.events	Normal	{"object": {"kind":"SpannerAutoscaler","namespace":"spanner-autoscaler","name":"spannerautoscaler-sample","uid":"995dd40f-a9e1-11ea-8797-42010a920105","apiVersion":"spanner.mercari.com/v1alpha1","resourceVersion":"14436"}, "reason": "Updated", "message": "Updated number of nodes from 1 to 5"}
2020-06-09T00:03:37.858Z	DEBUG	controller-runtime.controller	Successfully Reconciled	{"controller": "spannerautoscaler", "request": "spanner-autoscaler/spannerautoscaler-sample"}
```

</detail>

This PR makes the process skip until 10 seconds have passed since the last scale up.

## Which issue(s) this PR fixes

<!--
    Please specify the related issue.
    If there is no issue related to this PR, first of all you should consider creating an issue.
-->
Fixes #
