### PR TITLE
Add EventRecorder to syncer

### DIFF
--- a/pkg/controllers/spannerautoscaler_controller.go
+++ b/pkg/controllers/spannerautoscaler_controller.go
@@ -251,7 +251,7 @@ func (r *SpannerAutoscalerReconciler) SetupWithManager(mgr ctrlmanager.Manager) 
 func (r *SpannerAutoscalerReconciler) startSyncer(ctx context.Context, nn types.NamespacedName, projectID, instanceID string, serviceAccountJSON []byte) error {
 	log := logging.FromContext(ctx)
 
-	s, err := syncer.New(ctx, r.ctrlClient, nn, projectID, instanceID, serviceAccountJSON, syncer.WithLog(log))
+	s, err := syncer.New(ctx, r.ctrlClient, nn, projectID, instanceID, serviceAccountJSON, r.recoder, syncer.WithLog(log))
 	if err != nil {
 		return err
 	}

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -4,17 +4,15 @@ import (
 	"context"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
-
-	"k8s.io/client-go/tools/record"
-
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/clock"
+	"k8s.io/client-go/tools/record"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	spannerv1alpha1 "github.com/mercari/spanner-autoscaler/pkg/api/v1alpha1"


### PR DESCRIPTION
<!--
    Please read the CLA carefully before submitting your contribution to Mercari.
    Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
    https://www.mercari.com/cla/
-->

## What this PR does / Why we need it

Currently, errors in `syncer`'s unexported method are not being sent as Kubernetes events.
Custom Resource users will be able to check errors such as GetInstance and GetInstanceMetrics API for Cloud Spanner.

Example as follows:

```console
$ kubectl get events -n spanner-autoscaler
LAST SEEN   TYPE      REASON                 OBJECT                                             MESSAGE
...
5m59s       Warning   FailedSpannerAPICall   spannerautoscaler/spannerautoscaler-sample         no such spanner instance metrics
59s         Warning   FailedSpannerAPICall   spannerautoscaler/spannerautoscaler-sample         rpc error: code = NotFound desc = Instance not found: projects/myproject/instances/test-instance
```

## Which issue(s) this PR fixes

<!--
    Please specify the related issue.
    If there is no issue related to this PR, first of all you should consider creating an issue.
-->
Fixes #
