### PR TITLE
Add project id and instance id to kubernetes event

### DIFF
--- a/pkg/controllers/spannerautoscaler_controller.go
+++ b/pkg/controllers/spannerautoscaler_controller.go
@@ -219,7 +219,7 @@ func (r *SpannerAutoscalerReconciler) Reconcile(req ctrlreconcile.Request) (ctrl
 		return ctrlreconcile.Result{}, err
 	}
 
-	r.recoder.Eventf(&sa, corev1.EventTypeNormal, "Updated", "Updated number of nodes from %d to %d", *sa.Status.CurrentNodes, desiredNodes)
+	r.recoder.Eventf(&sa, corev1.EventTypeNormal, "Updated", "Updated number of %s/%s nodes from %d to %d", *sa.Spec.ScaleTargetRef.ProjectID, *sa.Spec.ScaleTargetRef.InstanceID, *sa.Status.CurrentNodes, desiredNodes)
 
 	log.Info("updated nodes via google cloud api", "before", *sa.Status.CurrentNodes, "after", desiredNodes)
 


### PR DESCRIPTION
<!--
    Please read the CLA carefully before submitting your contribution to Mercari.
    Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
    https://www.mercari.com/cla/
-->

## What this PR does / Why we need it

Currently, when the number of nodes is increased/decreased the message is as follows:

>Updated number of nodes from 2 to 1

Add the project ID and instance ID to the message to make it easier to identify which GCP project and Spanner instance the event occurred in.

## Which issue(s) this PR fixes

<!--
    Please specify the related issue.
    If there is no issue related to this PR, first of all you should consider creating an issue.
-->
Fixes #
