### PR TITLE
Set OutputPaths to zap

### DIFF
--- a/cmd/spanner-autoscaler/main.go
+++ b/cmd/spanner-autoscaler/main.go
@@ -117,7 +117,7 @@ func run() error {
 		return fmt.Errorf("failed to register readyz checker: %w", err)
 	}
 
-	r := controllers.NewSpannerAutoscalerReconciler(
+	r, err := controllers.NewSpannerAutoscalerReconciler(
 		mgr.GetClient(),
 		mgr.GetAPIReader(),
 		mgr.GetScheme(),
@@ -125,6 +125,10 @@ func run() error {
 		controllers.WithLog(log.WithName("controllers")),
 		controllers.WithScaleDownInterval(*scaleDownInterval),
 	)
+	if err != nil {
+		return err
+	}
+
 	if err = r.SetupWithManager(mgr); err != nil {
 		return err
 	}

--- a/pkg/controllers/spannerautoscaler_controller.go
+++ b/pkg/controllers/spannerautoscaler_controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -106,8 +107,25 @@ func NewSpannerAutoscalerReconciler(
 	recorder record.EventRecorder,
 	opts ...Option,
 ) (*SpannerAutoscalerReconciler, error) {
-	config := zap.NewProductionConfig()
-	config.OutputPaths = []string{"stdout"}
+	config := zap.Config{
+		Level:             zap.NewAtomicLevelAt(zap.InfoLevel),
+		Development:       false,
+		Encoding:          "json",
+		DisableCaller:     true,
+		DisableStacktrace: true,
+		EncoderConfig: zapcore.EncoderConfig{
+			TimeKey:        "timestamp",
+			LevelKey:       "level",
+			NameKey:        "logger",
+			MessageKey:     "message",
+			LineEnding:     zapcore.DefaultLineEnding,
+			EncodeLevel:    zapcore.LowercaseLevelEncoder,
+			EncodeTime:     zapcore.EpochMillisTimeEncoder,
+			EncodeDuration: zapcore.SecondsDurationEncoder,
+		},
+		OutputPaths:      []string{"stdout"},
+		ErrorOutputPaths: []string{"stderr"},
+	}
 	zapLogger, err := config.Build()
 	if err != nil {
 		return nil, err

--- a/pkg/controllers/spannerautoscaler_controller_test.go
+++ b/pkg/controllers/spannerautoscaler_controller_test.go
@@ -159,7 +159,7 @@ func TestSpannerAutoscalerReconciler_Reconcile(t *testing.T) {
 				t.Fatalf("unable to update SpannerAutoscaler status: %v", err)
 			}
 
-			r := NewSpannerAutoscalerReconciler(
+			r, err := NewSpannerAutoscalerReconciler(
 				cli,
 				cli,
 				s,
@@ -172,6 +172,9 @@ func TestSpannerAutoscalerReconciler_Reconcile(t *testing.T) {
 				WithScaleDownInterval(time.Hour),
 				WithClock(clock.NewFakeClock(fakeTime)),
 			)
+			if err != nil {
+				t.Fatalf("unable to create SpannerAutoscalerReconciler: %v", err)
+			}
 
 			res, err := r.Reconcile(ctrlreconcile.Request{
 				NamespacedName: namespacedName,


### PR DESCRIPTION
<!--
    Please read the CLA carefully before submitting your contribution to Mercari.
    Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
    https://www.mercari.com/cla/
-->

## What this PR does / Why we need it

Currently, all log levels are logged in the stderr.
Logs such as the `Info()` should be output to the stdout.

## Which issue(s) this PR fixes

<!--
    Please specify the related issue.
    If there is no issue related to this PR, first of all you should consider creating an issue.
-->
Fixes #
