### PR TITLE
Fix logger configuration

### DIFF
--- a/pkg/controllers/spannerautoscaler_controller_test.go
+++ b/pkg/controllers/spannerautoscaler_controller_test.go
@@ -159,11 +159,12 @@ func TestSpannerAutoscalerReconciler_Reconcile(t *testing.T) {
 				t.Fatalf("unable to update SpannerAutoscaler status: %v", err)
 			}
 
-			r, err := NewSpannerAutoscalerReconciler(
+			r := NewSpannerAutoscalerReconciler(
 				cli,
 				cli,
 				s,
 				record.NewFakeRecorder(10),
+				zapr.NewLogger(zap.NewNop()),
 				WithSyncers(tt.fields.syncers),
 				WithLog(func() logr.Logger {
 					l := zap.NewAtomicLevelAt(zap.DebugLevel)
@@ -172,9 +173,6 @@ func TestSpannerAutoscalerReconciler_Reconcile(t *testing.T) {
 				WithScaleDownInterval(time.Hour),
 				WithClock(clock.NewFakeClock(fakeTime)),
 			)
-			if err != nil {
-				t.Fatalf("unable to create SpannerAutoscalerReconciler: %v", err)
-			}
 
 			res, err := r.Reconcile(ctrlreconcile.Request{
 				NamespacedName: namespacedName,


### PR DESCRIPTION
<!--
    Please read the CLA carefully before submitting your contribution to Mercari.
    Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
    https://www.mercari.com/cla/
-->

## What this PR does / Why we need it

- Fix https://github.com/mercari/spanner-autoscaler/pull/23
- The log format changes are as follows:

### before

```
2020-09-10T09:30:49.791Z	INFO	controller-runtime.controller	Starting EventSource	{"controller": "spannerautoscaler", "source": "kind source: /, Kind="}
```

### after

```
{"level":"info","timestamp":1599740678066.0408,"logger":"controller-runtime.controller","message":"Starting EventSource","controller":"spannerautoscaler","source":"kind source: /, Kind="}
```

## Which issue(s) this PR fixes

<!--
    Please specify the related issue.
    If there is no issue related to this PR, first of all you should consider creating an issue.
-->
Fixes #
