### PR TITLE
Support Processing Units

### DIFF
--- a/config/crd/bases/spanner.mercari.com_spannerautoscalers.yaml
+++ b/config/crd/bases/spanner.mercari.com_spannerautoscalers.yaml
@@ -80,7 +80,7 @@ spec:
               type: integer
             maxProcessingUnits:
               description: upper limit for the number of nodes that can be set by
-                the autoscaler. It cannot be smaller than MinProcessingUnits.
+                the autoscaler. It cannot be smaller than minProcessingUnits.
               format: int32
               minimum: 100
               type: integer

--- a/config/crd/bases/spanner.mercari.com_spannerautoscalers.yaml
+++ b/config/crd/bases/spanner.mercari.com_spannerautoscalers.yaml
@@ -15,6 +15,12 @@ spec:
   - JSONPath: .spec.scaleTargetRef.instanceId
     name: Instance Id
     type: string
+  - JSONPath: .spec.minNodes
+    name: Min Nodes
+    type: integer
+  - JSONPath: .spec.maxNodes
+    name: Max Nodes
+    type: integer
   - JSONPath: .spec.minProcessingUnits
     name: Min PUs
     type: integer

--- a/config/crd/bases/spanner.mercari.com_spannerautoscalers.yaml
+++ b/config/crd/bases/spanner.mercari.com_spannerautoscalers.yaml
@@ -15,11 +15,11 @@ spec:
   - JSONPath: .spec.scaleTargetRef.instanceId
     name: Instance Id
     type: string
-  - JSONPath: .spec.minNodes
-    name: Min Nodes
+  - JSONPath: .spec.minProcessingUnits
+    name: Min PUs
     type: integer
-  - JSONPath: .spec.maxNodes
-    name: Max Nodes
+  - JSONPath: .spec.maxProcessingUnits
+    name: Max PUs
     type: integer
   - JSONPath: .spec.targetCPUUtilization.highPriority
     name: Target CPU
@@ -72,6 +72,12 @@ spec:
               format: int32
               minimum: 1
               type: integer
+            maxProcessingUnits:
+              description: upper limit for the number of nodes that can be set by
+                the autoscaler. It cannot be smaller than MinProcessingUnits.
+              format: int32
+              minimum: 100
+              type: integer
             maxScaleDownNodes:
               description: upper limit for the number of nodes when autoscaler scaledown.
               format: int32
@@ -82,6 +88,12 @@ spec:
                 the autoscaler.
               format: int32
               minimum: 1
+              type: integer
+            minProcessingUnits:
+              description: lower limit for the number of nodes that can be set by
+                the autoscaler.
+              format: int32
+              minimum: 100
               type: integer
             scaleTargetRef:
               description: target reference for scaling.
@@ -126,8 +138,6 @@ spec:
               - highPriority
               type: object
           required:
-          - maxNodes
-          - minNodes
           - scaleTargetRef
           - targetCPUUtilization
           type: object
@@ -143,7 +153,15 @@ spec:
               description: current number of nodes of Spanner managed by this autoscaler.
               format: int32
               type: integer
+            currentProcessingUnits:
+              description: current number of nodes of Spanner managed by this autoscaler.
+              format: int32
+              type: integer
             desiredNodes:
+              description: desired number of nodes of Spanner managed by this autoscaler.
+              format: int32
+              type: integer
+            desiredProcessingUnits:
               description: desired number of nodes of Spanner managed by this autoscaler.
               format: int32
               type: integer

--- a/pkg/api/v1alpha1/spannerautoscaler_types.go
+++ b/pkg/api/v1alpha1/spannerautoscaler_types.go
@@ -88,7 +88,7 @@ type SpannerAutoscalerSpec struct {
 	// +kubebuilder:validation:MultipleOf=100
 	// +kubebuilder:validation:Optional
 	// upper limit for the number of nodes that can be set by the autoscaler.
-	// It cannot be smaller than MinProcessingUnits.
+	// It cannot be smaller than minProcessingUnits.
 	MaxProcessingUnits *int32 `json:"maxProcessingUnits,omitempty"`
 
 	// +kubebuilder:validation:Minimum=1

--- a/pkg/api/v1alpha1/spannerautoscaler_types.go
+++ b/pkg/api/v1alpha1/spannerautoscaler_types.go
@@ -68,13 +68,26 @@ type SpannerAutoscalerSpec struct {
 	ImpersonateConfig *ImpersonateConfig `json:"impersonateConfig,omitempty"`
 
 	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Optional
 	// lower limit for the number of nodes that can be set by the autoscaler.
-	MinNodes *int32 `json:"minNodes"`
+	MinNodes *int32 `json:"minNodes,omitempty"`
 
 	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Optional
 	// upper limit for the number of nodes that can be set by the autoscaler.
 	// It cannot be smaller than MinNodes.
-	MaxNodes *int32 `json:"maxNodes"`
+	MaxNodes *int32 `json:"maxNodes,omitempty"`
+
+	// +kubebuilder:validation:Minimum=100
+	// +kubebuilder:validation:Optional
+	// lower limit for the number of nodes that can be set by the autoscaler.
+	MinProcessingUnits *int32 `json:"minProcessingUnits,omitempty"`
+
+	// +kubebuilder:validation:Minimum=100
+	// +kubebuilder:validation:Optional
+	// upper limit for the number of nodes that can be set by the autoscaler.
+	// It cannot be smaller than MinProcessingUnits.
+	MaxProcessingUnits *int32 `json:"maxProcessingUnits,omitempty"`
 
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Optional
@@ -110,8 +123,14 @@ type SpannerAutoscalerStatus struct {
 	// current number of nodes of Spanner managed by this autoscaler.
 	CurrentNodes *int32 `json:"currentNodes,omitempty"`
 
+	// current number of nodes of Spanner managed by this autoscaler.
+	CurrentProcessingUnits *int32 `json:"currentProcessingUnits,omitempty"`
+
 	// desired number of nodes of Spanner managed by this autoscaler.
 	DesiredNodes *int32 `json:"desiredNodes,omitempty"`
+
+	// desired number of nodes of Spanner managed by this autoscaler.
+	DesiredProcessingUnits *int32 `json:"desiredProcessingUnits,omitempty"`
 
 	// +kubebuilder:validation:Type=string
 	InstanceState InstanceState `json:"instanceState"`
@@ -125,8 +144,8 @@ type SpannerAutoscalerStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Project Id",type="string",JSONPath=".spec.scaleTargetRef.projectId"
 // +kubebuilder:printcolumn:name="Instance Id",type="string",JSONPath=".spec.scaleTargetRef.instanceId"
-// +kubebuilder:printcolumn:name="Min Nodes",type="integer",JSONPath=".spec.minNodes"
-// +kubebuilder:printcolumn:name="Max Nodes",type="integer",JSONPath=".spec.maxNodes"
+// +kubebuilder:printcolumn:name="Min PUs",type="integer",JSONPath=".spec.minProcessingUnits"
+// +kubebuilder:printcolumn:name="Max PUs",type="integer",JSONPath=".spec.maxProcessingUnits"
 // +kubebuilder:printcolumn:name="Target CPU",type="integer",JSONPath=".spec.targetCPUUtilization.highPriority"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 

--- a/pkg/api/v1alpha1/spannerautoscaler_types.go
+++ b/pkg/api/v1alpha1/spannerautoscaler_types.go
@@ -79,11 +79,13 @@ type SpannerAutoscalerSpec struct {
 	MaxNodes *int32 `json:"maxNodes,omitempty"`
 
 	// +kubebuilder:validation:Minimum=100
+	// +kubebuilder:validation:MultipleOf=100
 	// +kubebuilder:validation:Optional
 	// lower limit for the number of nodes that can be set by the autoscaler.
 	MinProcessingUnits *int32 `json:"minProcessingUnits,omitempty"`
 
 	// +kubebuilder:validation:Minimum=100
+	// +kubebuilder:validation:MultipleOf=100
 	// +kubebuilder:validation:Optional
 	// upper limit for the number of nodes that can be set by the autoscaler.
 	// It cannot be smaller than MinProcessingUnits.

--- a/pkg/api/v1alpha1/spannerautoscaler_types.go
+++ b/pkg/api/v1alpha1/spannerautoscaler_types.go
@@ -144,6 +144,8 @@ type SpannerAutoscalerStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Project Id",type="string",JSONPath=".spec.scaleTargetRef.projectId"
 // +kubebuilder:printcolumn:name="Instance Id",type="string",JSONPath=".spec.scaleTargetRef.instanceId"
+// +kubebuilder:printcolumn:name="Min Nodes",type="integer",JSONPath=".spec.minNodes"
+// +kubebuilder:printcolumn:name="Max Nodes",type="integer",JSONPath=".spec.maxNodes"
 // +kubebuilder:printcolumn:name="Min PUs",type="integer",JSONPath=".spec.minProcessingUnits"
 // +kubebuilder:printcolumn:name="Max PUs",type="integer",JSONPath=".spec.maxProcessingUnits"
 // +kubebuilder:printcolumn:name="Target CPU",type="integer",JSONPath=".spec.targetCPUUtilization.highPriority"

--- a/pkg/controllers/spannerautoscaler_controller.go
+++ b/pkg/controllers/spannerautoscaler_controller.go
@@ -353,6 +353,7 @@ func nextValidProcessingUnits(processingUnits int32) int32 {
 	return ((processingUnits / 1000) + 1) * 1000
 }
 
+// calcDesiredProcessingUnits calculates the values needed to keep CPU utilization below TargetCPU.
 func calcDesiredProcessingUnits(currentCPU, currentProcessingUnits, targetCPU, minProcessingUnits, maxProcessingUnits, maxScaleDownNodes int32) int32 {
 	totalCPUProduct1000 := currentCPU * currentProcessingUnits
 

--- a/pkg/controllers/spannerautoscaler_controller.go
+++ b/pkg/controllers/spannerautoscaler_controller.go
@@ -294,7 +294,7 @@ func (r *SpannerAutoscalerReconciler) needCalcProcessingUnits(sa *spannerv1alpha
 
 	switch {
 	case sa.Status.CurrentProcessingUnits == nil && sa.Status.CurrentNodes == nil:
-		log.Info("current nodes have not fetched yet")
+		log.Info("current processing units have not fetched yet")
 		return false
 
 	case sa.Status.InstanceState != spanner.StateReady:

--- a/pkg/controllers/spannerautoscaler_controller.go
+++ b/pkg/controllers/spannerautoscaler_controller.go
@@ -353,15 +353,21 @@ func nextValidProcessingUnits(processingUnits int32) int32 {
 	return ((processingUnits / 1000) + 1) * 1000
 }
 
+func maxInt32(first int32, rest ...int32) int32 {
+	result := first
+	for _, v := range rest {
+		if result < v {
+			result = v
+		}
+	}
+	return result
+}
+
 // calcDesiredProcessingUnits calculates the values needed to keep CPU utilization below TargetCPU.
 func calcDesiredProcessingUnits(currentCPU, currentProcessingUnits, targetCPU, minProcessingUnits, maxProcessingUnits, maxScaleDownNodes int32) int32 {
 	totalCPUProduct1000 := currentCPU * currentProcessingUnits
 
-	desiredProcessingUnits := nextValidProcessingUnits(totalCPUProduct1000 / targetCPU)
-
-	if (currentProcessingUnits - desiredProcessingUnits) > maxScaleDownNodes*1000 {
-		desiredProcessingUnits = currentProcessingUnits - maxScaleDownNodes*1000
-	}
+	desiredProcessingUnits := maxInt32(nextValidProcessingUnits(totalCPUProduct1000 / targetCPU), currentProcessingUnits - maxScaleDownNodes*1000)
 
 	switch {
 	case desiredProcessingUnits < minProcessingUnits:

--- a/pkg/controllers/spannerautoscaler_controller_test.go
+++ b/pkg/controllers/spannerautoscaler_controller_test.go
@@ -573,6 +573,27 @@ func Test_calcDesiredProcessingUnits(t *testing.T) {
 	}
 }
 
+func TestNextValidProcessingUnits(t *testing.T) {
+	tests := []struct {
+		input int32
+	    want  int32
+	}{
+		{input: 0, want: 100},
+		{input: 99, want: 100},
+		{input: 100, want: 200},
+		{input: 900, want: 1000},
+		{input: 1000, want: 2000},
+		{input: 1999, want: 2000},
+		{input: 2000, want: 3000},
+	}
+	for _, tt := range tests {
+		got := nextValidProcessingUnits(tt.input)
+		if got != tt.want {
+			t.Errorf("TestNextValidProcessingUnits(%v) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
 func TestSpannerAutoscalerReconciler_fetchCredentials(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/pkg/controllers/spannerautoscaler_controller_test.go
+++ b/pkg/controllers/spannerautoscaler_controller_test.go
@@ -515,7 +515,7 @@ func Test_calcDesiredProcessingUnits(t *testing.T) {
 			want: 4000,
 		},
 		{
-			name: "scale down to min nodes",
+			name: "scale down to min PUs",
 			args: args{
 				currentCPU:             0,
 				currentProcessingUnits: 500,
@@ -527,7 +527,7 @@ func Test_calcDesiredProcessingUnits(t *testing.T) {
 			want: 100,
 		},
 		{
-			name: "scale down to min PUs",
+			name: "scale down to min PUs 2",
 			args: args{
 				currentCPU:             0,
 				currentProcessingUnits: 5000,
@@ -539,16 +539,16 @@ func Test_calcDesiredProcessingUnits(t *testing.T) {
 			want: 1000,
 		},
 		{
-			name: "scale down to min PUs 3",
+			name: "scale down to min PUs",
 			args: args{
-				currentCPU:             30,
-				currentProcessingUnits: 500,
+				currentCPU:             0,
+				currentProcessingUnits: 5000,
 				targetCPU:              50,
-				minProcessingUnits:     500,
-				maxProcessingUnits:     1000,
-				maxScaleDownNodes:      2,
+				minProcessingUnits:     100,
+				maxProcessingUnits:     10000,
+				maxScaleDownNodes:      5,
 			},
-			want: 500,
+			want: 100,
 		},
 		{
 			name: "scale down with max scale down nodes",

--- a/pkg/controllers/spannerautoscaler_controller_test.go
+++ b/pkg/controllers/spannerautoscaler_controller_test.go
@@ -134,6 +134,7 @@ func TestSpannerAutoscalerReconciler_Reconcile(t *testing.T) {
 			want: func() *spannerv1alpha1.SpannerAutoscaler {
 				o := baseObj.DeepCopy()
 				o.Status.DesiredNodes = pointer.Int32(6)
+				o.Status.DesiredProcessingUnits = pointer.Int32(6000)
 				o.Status.InstanceState = spannerv1alpha1.InstanceStateReady
 				o.Status.LastScaleTime = &metav1.Time{Time: fakeTime}
 				return o
@@ -254,9 +255,9 @@ func TestSpannerAutoscalerReconciler_needCalcNodes(t *testing.T) {
 				clock:             clock.NewFakeClock(fakeTime),
 				log:               zapr.NewLogger(zap.NewNop()),
 			}
-			got := r.needCalcNodes(tt.args.sa)
+			got := r.needCalcProcessingUnits(tt.args.sa)
 			if got != tt.want {
-				t.Errorf("needCalcNodes() got = %v, want %v", got, tt.want)
+				t.Errorf("needCalcProcessingUnits() got = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -310,9 +311,9 @@ func TestSpannerAutoscalerReconciler_needUpdateNodes(t *testing.T) {
 				clock:             clock.NewFakeClock(fakeTime),
 				log:               zapr.NewLogger(zap.NewNop()),
 			}
-			got := r.needUpdateNodes(tt.args.sa, *tt.args.sa.Status.DesiredNodes, fakeTime)
+			got := r.needUpdateProcessingUnits(tt.args.sa, normalizeProcessingUnitsOrNodes(tt.args.sa.Status.DesiredProcessingUnits, tt.args.sa.Status.DesiredNodes), fakeTime)
 			if got != tt.want {
-				t.Errorf("needUpdateNodes() got = %v, want %v", got, tt.want)
+				t.Errorf("needUpdateProcessingUnits() got = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -409,7 +410,7 @@ func Test_calcDesiredNodes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := calcDesiredNodes(tt.args.currentCPU, tt.args.currentNodes, tt.args.targetCPU, tt.args.minNodes, tt.args.maxNodes, tt.args.maxScaleDownNodes); got != tt.want {
-				t.Errorf("calcDesiredNodes() = %v, want %v", got, tt.want)
+				t.Errorf("calcDesiredProcessingUnits() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/spanner/spanner.go
+++ b/pkg/spanner/spanner.go
@@ -29,8 +29,8 @@ const (
 
 // Instance represents Spanner Instance.
 type Instance struct {
-	NodeCount     *int32
-	InstanceState State
+	ProcessingUnits *int32
+	InstanceState   State
 }
 
 // Client is a client for manipulation of Instance.
@@ -106,8 +106,8 @@ func (c *client) GetInstance(ctx context.Context, instanceID string) (*Instance,
 	}
 
 	return &Instance{
-		NodeCount:     pointer.Int32(i.NodeCount),
-		InstanceState: instanceState(i.State),
+		ProcessingUnits: pointer.Int32(i.ProcessingUnits),
+		InstanceState:   instanceState(i.State),
 	}, nil
 }
 
@@ -123,14 +123,14 @@ func (c *client) UpdateInstance(ctx context.Context, instanceID string, instance
 		return err
 	}
 
-	if instance.NodeCount != nil {
-		i.NodeCount = *instance.NodeCount
+	if instance.ProcessingUnits != nil {
+		i.ProcessingUnits = *instance.ProcessingUnits
 	}
 
 	_, err = c.spannerInstanceAdminClient.UpdateInstance(ctx, &instancepb.UpdateInstanceRequest{
 		Instance: i,
 		FieldMask: &field_mask.FieldMask{
-			Paths: []string{"node_count"},
+			Paths: []string{"processing_units"},
 		},
 	})
 	if err != nil {

--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -87,8 +87,8 @@ func Test_syncer_syncResource(t *testing.T) {
 			name: "sync and update instance",
 			fakeInstances: map[string]*spanner.Instance{
 				fakeInstanceID: {
-					NodeCount:     pointer.Int32(3),
-					InstanceState: spanner.StateReady,
+					ProcessingUnits: pointer.Int32(3000),
+					InstanceState:   spanner.StateReady,
 				},
 			},
 			fakeMetrics: map[string]*metrics.InstanceMetrics{
@@ -103,6 +103,7 @@ func Test_syncer_syncResource(t *testing.T) {
 			want: func() *spannerv1alpha1.SpannerAutoscaler {
 				o := fakeSpannerAutoscaler.DeepCopy()
 				o.Status.CurrentNodes = pointer.Int32(3)
+				o.Status.CurrentProcessingUnits = pointer.Int32(3000)
 				o.Status.InstanceState = spannerv1alpha1.InstanceStateReady
 				o.Status.CurrentHighPriorityCPUUtilization = pointer.Int32(30)
 				o.Status.LastSyncTime = &metav1.Time{Time: fakeTime}
@@ -194,8 +195,8 @@ func Test_syncer_getInstanceInfo(t *testing.T) {
 			name: "get instance info",
 			fakeInstances: map[string]*spanner.Instance{
 				fakeInstanceID: {
-					NodeCount:     pointer.Int32(1),
-					InstanceState: spanner.StateReady,
+					ProcessingUnits: pointer.Int32(1000),
+					InstanceState:   spanner.StateReady,
 				},
 			},
 			fakeMetrics: map[string]*metrics.InstanceMetrics{
@@ -204,8 +205,8 @@ func Test_syncer_getInstanceInfo(t *testing.T) {
 				},
 			},
 			wantInstance: &spanner.Instance{
-				NodeCount:     pointer.Int32(1),
-				InstanceState: spanner.StateReady,
+				ProcessingUnits: pointer.Int32(1000),
+				InstanceState:   spanner.StateReady,
 			},
 			wantInstanceMetrics: &metrics.InstanceMetrics{
 				CurrentHighPriorityCPUUtilization: pointer.Int32(50),


### PR DESCRIPTION
<!--
    Please read the CLA carefully before submitting your contribution to Mercari.
    Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
    https://www.mercari.com/cla/
-->

## What this PR does / Why we need it

To keep compatibility, this PR simply adds

- spec
    - maxProcessingUnits
    - minProcessingUnits
- status
    - desiredProcessingUnits
    - currentProcessingUnits

and support both of `*ProcessingUnits` and `*Nodes`.

In wording, I want to propose:

* Use "compute capacity" as the abstract term.
* Use "processing units(PU)" as the base unit for compute capacity.
* Use "nodes" as the supplementary unit which is equals to 1000 PU.

See also https://cloud.google.com/spanner/docs/compute-capacity?hl=en for the official use of these terms.

## Which issue(s) this PR fixes

<!--
    Please specify the related issue.
    If there is no issue related to this PR, first of all you should consider creating an issue.
-->
Fixes #26 