### PR TITLE
Rename workflow

### DIFF
--- a/.github/workflows/check-tag.yml
+++ b/.github/workflows/check-tag.yml
@@ -1,31 +1,31 @@
-name: Check Release
+name: Check Tag Bump
 
 on:
   pull_request_target:
     types: [labeled]
 
 jobs:
-  release:
+  bump-tag-check:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
 
       - uses: actions-ecosystem/action-release-label@v1
-        id: release-label
+        id: bump-label
         if: ${{ startsWith(github.event.label.name, 'release/') }}
 
       - uses: actions-ecosystem/action-get-latest-tag@v1
         id: get-latest-tag
-        if: ${{ steps.release-label.outputs.level != null }}
+        if: ${{ steps.bump-label.outputs.level != null }}
         with:
           semver_only: true
 
       - uses: actions-ecosystem/action-bump-semver@v1
         id: bump-semver
-        if: ${{ steps.release-label.outputs.level != null }}
+        if: ${{ steps.bump-label.outputs.level != null }}
         with:
           current_version: ${{ steps.get-latest-tag.outputs.tag }}
-          level: ${{ steps.release-label.outputs.level }}
+          level: ${{ steps.bump-label.outputs.level }}
 
       - uses: actions-ecosystem/action-create-comment@v1
         if: ${{ steps.bump-semver.outputs.new_version != null }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,4 +1,4 @@
-name: Create Release
+name: Create SemVer Tag
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
       - master
 
 jobs:
-  release:
+  bump-tag:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
@@ -17,24 +17,23 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions-ecosystem/action-release-label@v1
-        id: release-label
+        id: bump-label
         if: ${{ steps.get-merged-pull-request.outputs.title != null }}
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: ${{ steps.get-merged-pull-request.outputs.labels }}
 
       - uses: actions-ecosystem/action-get-latest-tag@v1
         id: get-latest-tag
-        if: ${{ steps.release-label.outputs.level != null }}
+        if: ${{ steps.bump-label.outputs.level != null }}
         with:
           semver_only: true
 
       - uses: actions-ecosystem/action-bump-semver@v1
         id: bump-semver
-        if: ${{ steps.release-label.outputs.level != null }}
+        if: ${{ steps.bump-label.outputs.level != null }}
         with:
           current_version: ${{ steps.get-latest-tag.outputs.tag }}
-          level: ${{ steps.release-label.outputs.level }}
+          level: ${{ steps.bump-label.outputs.level }}
 
       - uses: actions-ecosystem/action-push-tag@v1
         if: ${{ steps.bump-semver.outputs.new_version != null }}
@@ -43,7 +42,7 @@ jobs:
           message: "${{ steps.bump-semver.outputs.new_version }}: PR #${{ steps.get-merged-pull-request.outputs.number }} ${{ steps.get-merged-pull-request.outputs.title }}"
 
       - uses: goreleaser/goreleaser-action@v2
-        if: ${{ steps.release-label.outputs.level == 'major' || steps.release-label.outputs.level == 'minor' || steps.release-label.outputs.level == 'patch' }}
+        if: ${{ steps.bump-label.outputs.level == 'major' || steps.bump-label.outputs.level == 'minor' || steps.bump-label.outputs.level == 'patch' }}
         with:
           version: v0.143.0
           args: release --rm-dist
@@ -64,6 +63,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           number: ${{ steps.get-merged-pull-request.outputs.number }}
           body: |
-            The new version [${{ steps.bump-semver.outputs.new_version }}](https://github.com/${{ github.repository }}/releases/tag/${{ steps.bump-semver.outputs.new_version }}) has been released :tada:
+            The new version [${{ steps.bump-semver.outputs.new_version }}](https://github.com/${{ github.repository }}/releases/tag/${{ steps.bump-semver.outputs.new_version }}) has been tagged :tada:
 
             Changes: https://github.com/${{ github.repository }}/compare/${{ steps.get-latest-tag.outputs.tag }}...${{ steps.bump-semver.outputs.new_version }}


### PR DESCRIPTION
* Current workflows don't actually create a release, they just bump
  the tag version (based on the `release/*` label on PR). Thus, call it
  a `tag` and not a `release`, because it becomes misleading.
* Fix: remove `github_token` input variable from `action-release-label`
  action
