### PR TITLE
Fix `main.go` path in `.goreleaser.yml`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,8 +1,7 @@
 changelog:
   use: github-native
 builds:
-- main: ./cmd/spanner-autoscaler/main.go
-  goos:
+- goos:
   - linux
   - darwin
   - windows


### PR DESCRIPTION
Fix Broken CI - https://github.com/mercari/spanner-autoscaler/runs/4849637737?check_suite_focus=true#step:4:39