### PR TITLE
Fix the CI workflows to pass secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ on:
         description: The semantic tag version against which the release will be created
         required: true
         type: string
+    secrets:
+      DOCKER_USERNAME:
+        required: true
+      DOCKER_PASSWORD:
+        required: true
   push:
     tags:
       - v*

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -64,5 +64,8 @@ jobs:
     needs: bump-tag
     if: ${{ needs.bump-tag.outputs.new_version != null }}
     uses: mercari/spanner-autoscaler/.github/workflows/release.yml@master
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
     with:
       version: ${{ needs.bump-tag.outputs.new_version }}


### PR DESCRIPTION
Fix the bug we hit - https://github.community/t/reusable-workflows-secrets-and-environments/203695/6
This was preventing the release workflow from logging in to DockerHub (due to missing secrets access).

EDIT: Reference doc for this - https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow