### PR TITLE
Fix CI: goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,11 @@ jobs:
         env:
           CURRENT_TAG: ${{ inputs.version }}
 
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+
       - name: Create Github Release
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,9 @@
 changelog:
   use: github-native
+before:
+  hooks:
+  - go mod tidy
+  - go mod download
 builds:
 - goos:
   - linux

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	cloud.google.com/go/monitoring v1.2.0
 	cloud.google.com/go/spanner v1.25.0
 	github.com/go-logr/logr v0.4.0
-	github.com/go-logr/zapr v0.4.0
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.6
 	github.com/google/uuid v1.3.0
@@ -38,6 +37,7 @@ require (
 	github.com/envoyproxy/protoc-gen-validate v0.1.0 // indirect
 	github.com/evanphx/json-patch v4.11.0+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/go-logr/zapr v0.4.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/gofuzz v1.1.0 // indirect


### PR DESCRIPTION
The last CI job has failed (3 unsuccessful attempts) - https://github.com/mercari/spanner-autoscaler/actions/runs/1782580338
Probably because of cache... or some other missing dependency...

As a fix:
- setup golang before running `goreleaser`
- download the dependencies beforehand [[Ref](https://goreleaser.com/customization/build/#go-modules)], 