### PR TITLE
Add `delete` functionality for schedule resources

### DIFF
--- a/config/crd/bases/spanner.mercari.com_spannerautoscaleschedules.yaml
+++ b/config/crd/bases/spanner.mercari.com_spannerautoscaleschedules.yaml
@@ -40,10 +40,6 @@ spec:
             properties:
               additionalProcessingUnits:
                 type: integer
-              foo:
-                description: Foo is an example field of SpannerAutoscaleSchedule.
-                  Edit spannerautoscaleschedule_types.go to remove/update
-                type: string
               schedule:
                 properties:
                   cron:

--- a/controllers/spannerautoscaler_controller.go
+++ b/controllers/spannerautoscaler_controller.go
@@ -180,7 +180,7 @@ func NewSpannerAutoscalerReconciler(
 // Reconcile implements ctrlreconcile.Reconciler.
 func (r *SpannerAutoscalerReconciler) Reconcile(ctx context.Context, req ctrlreconcile.Request) (ctrlreconcile.Result, error) {
 	nn := req.NamespacedName
-	log := r.log.WithValues("namespaced name", nn, "emitter", "autoscaler")
+	log := r.log.WithValues("namespaced name", nn)
 
 	r.mu.RLock()
 	syncer, syncerExists := r.syncers[nn]

--- a/main.go
+++ b/main.go
@@ -143,6 +143,7 @@ func main() {
 	sasr := controllers.NewSpannerAutoscaleScheduleReconciler(
 		mgr.GetClient(),
 		mgr.GetScheme(),
+		mgr.GetEventRecorderFor("spannerautoscaleschedule-controller"),
 		controllers.WithLog(log),
 	)
 


### PR DESCRIPTION
### Contents of this PR:
- Add `delete` functionality for `SpannerAutoscaleSchedule` resources so that whenever a schedule resource is deleted, it should also de-register the schedule from the spanner-atuoscaler (implementation [ref](https://book.kubebuilder.io/reference/using-finalizers.html))
- Rename the import of `syncer` package to `syncerpkg`, to avoid confusion with the variable of the same name