### PR TITLE
Switch from command line flags to config file based options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,9 @@ kind-cluster-delete: kind ## Delete the kind cluster created for development
 
 kind-cluster-reset: kind-cluster-delete kind-cluster-create ## Recreate the kind cluster for development
 
+kind-load-docker-image: kind ## Load a local Docker image to the kind cluster for development
+	@$(KIND) load docker-image --name $(KIND_CLUSTER_NAME) ${IMG}
+
 ##@ Build
 
 build: generate fmt vet ## Build manager binary.

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -32,7 +32,7 @@ patchesStrategicMerge:
 
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type
-#- manager_config_patch.yaml
+- manager_config_patch.yaml
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -19,8 +19,3 @@ spec:
         ports:
         - containerPort: 8443
           name: https
-      - name: manager
-        args:
-        - "--health-probe-bind-address=:8081"
-        - "--metrics-bind-address=127.0.0.1:8080"
-        - "--leader-elect"


### PR DESCRIPTION
<!--
    Please read the CLA carefully before submitting your contribution to Mercari.
    Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
    https://www.mercari.com/cla/
-->

## What this PR does / Why we need it
Switched from command line flags to config file-based options. 
https://book.kubebuilder.io/component-config-tutorial/tutorial.html

## Which issue(s) this PR fixes

<!--
    Please specify the related issue.
    If there is no issue related to this PR, first of all you should consider creating an issue.
-->
None

## Steps to test the update

```
make kind-cluster-reset

export IMG=mercari/spanner-autoscaler:local
make docker-build && make kind-load-docker-image

kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.yaml
make deploy
```