### PR TITLE
Add validation webhook for `SpannerAutoscaleSchedule`

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -38,4 +38,7 @@ resources:
   kind: SpannerAutoscaleSchedule
   path: github.com/mercari/spanner-autoscaler/api/v1beta1
   version: v1beta1
+  webhooks:
+    validation: true
+    webhookVersion: v1
 version: "3"

--- a/api/v1beta1/spannerautoscaleschedule_webhook.go
+++ b/api/v1beta1/spannerautoscaleschedule_webhook.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"time"
+
+	cronpkg "github.com/robfig/cron/v3"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// log is for logging in this package.
+var spannerautoscaleschedulelog = logf.Log.WithName("spannerautoscaleschedule-resource.webhook")
+
+func (r *SpannerAutoscaleSchedule) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+//+kubebuilder:webhook:path=/validate-spanner-mercari-com-v1beta1-spannerautoscaleschedule,mutating=false,failurePolicy=fail,sideEffects=None,groups=spanner.mercari.com,resources=spannerautoscaleschedules,verbs=create;update,versions=v1beta1,name=vspannerautoscaleschedule.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Validator = &SpannerAutoscaleSchedule{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *SpannerAutoscaleSchedule) ValidateCreate() error {
+	spannerautoscaleschedulelog.Info("validate create", "name", r.Name)
+	spannerautoscaleschedulelog.V(1).Info("validating creation of SpannerAutoscaleSchedule resource", "name", r.Name, "resource", r)
+
+	allErrs := r.validateSchedule()
+
+	if len(allErrs) == 0 {
+		return nil
+	}
+
+	return apierrors.NewInvalid(
+		schema.GroupKind{Group: "spanner.mercari.com", Kind: "SpannerAutoscaleSchedule"},
+		r.Name, allErrs)
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *SpannerAutoscaleSchedule) ValidateUpdate(old runtime.Object) error {
+	spannerautoscaleschedulelog.Info("validate update", "name", r.Name)
+	spannerautoscaleschedulelog.V(1).Info("validating updates to SpannerAutoscaleSchedule resource", "name", r.Name, "resource", r)
+
+	var allErrs field.ErrorList
+	oldResource := old.(*SpannerAutoscaleSchedule)
+
+	// TargetResource should not be changed after creation
+	if oldResource.Spec.TargetResource != r.Spec.TargetResource {
+		err := field.Invalid(
+			field.NewPath("spec").Child("targetResource"),
+			r.Spec.TargetResource,
+			"'targetResource' can not be changed after resource has been created")
+		allErrs = append(allErrs, err)
+	}
+
+	// Disable schedule updates until reconciler is modified to propagate this change to the actual cronjobs
+	if oldResource.Spec.Schedule != r.Spec.Schedule {
+		err := field.Invalid(
+			field.NewPath("spec").Child("schedule"),
+			r.Spec.Schedule,
+			"'schedule' can not be changed after resource has been created")
+		allErrs = append(allErrs, err)
+	}
+
+	allErrs = append(allErrs, r.validateSchedule()...)
+
+	if len(allErrs) == 0 {
+		return nil
+	}
+
+	return apierrors.NewInvalid(
+		schema.GroupKind{Group: "spanner.mercari.com", Kind: "SpannerAutoscaleSchedule"},
+		r.Name, allErrs)
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *SpannerAutoscaleSchedule) ValidateDelete() error {
+	spannerautoscaleschedulelog.Info("validate delete", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object deletion.
+	return nil
+}
+
+func (r *SpannerAutoscaleSchedule) validateSchedule() field.ErrorList {
+	var allErrs field.ErrorList
+	cronSchedule, err := cronpkg.ParseStandard(r.Spec.Schedule.Cron)
+	if err != nil {
+		fldErr := field.Invalid(
+			field.NewPath("spec").Child("schedule").Child("cron"),
+			r.Spec.Schedule.Cron,
+			err.Error())
+		allErrs = append(allErrs, fldErr)
+	}
+
+	duration, err := time.ParseDuration(r.Spec.Schedule.Duration)
+	if err != nil {
+		fldErr := field.Invalid(
+			field.NewPath("spec").Child("schedule").Child("duration"),
+			r.Spec.Schedule.Duration,
+			err.Error())
+		allErrs = append(allErrs, fldErr)
+	}
+
+	// return early if either the cron schedule or the duration can not be parsed
+	if len(allErrs) != 0 {
+		return allErrs
+	}
+
+	now := time.Now()
+	firstRun := cronSchedule.Next(now)
+	secondRun := cronSchedule.Next(firstRun)
+
+	if secondRun.Before(firstRun.Add(duration)) {
+		fldErr := field.Invalid(
+			field.NewPath("spec").Child("schedule").Child("duration"),
+			r.Spec.Schedule.Duration,
+			"'duration' is larger than the time period between cron jobs of 'schedule'")
+		allErrs = append(allErrs, fldErr)
+	}
+
+	return allErrs
+}

--- a/api/v1beta1/webhook_suite_test.go
+++ b/api/v1beta1/webhook_suite_test.go
@@ -107,6 +107,9 @@ var _ = BeforeSuite(func() {
 	err = (&SpannerAutoscaler{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = (&SpannerAutoscaleSchedule{}).SetupWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
 	//+kubebuilder:scaffold:webhook
 
 	go func() {

--- a/config/deploy-dev/kustomization.yaml
+++ b/config/deploy-dev/kustomization.yaml
@@ -58,3 +58,9 @@ patches:
     - op: add
       path: /webhooks/0/timeoutSeconds
       value: 30
+    - op: add
+      path: /webhooks/1/clientConfig/service/port
+      value: 9443
+    - op: add
+      path: /webhooks/1/timeoutSeconds
+      value: 30

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -54,3 +54,23 @@ webhooks:
     resources:
     - spannerautoscalers
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-spanner-mercari-com-v1beta1-spannerautoscaleschedule
+  failurePolicy: Fail
+  name: vspannerautoscaleschedule.kb.io
+  rules:
+  - apiGroups:
+    - spanner.mercari.com
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - spannerautoscaleschedules
+  sideEffects: None

--- a/controllers/spannerautoscaler_controller.go
+++ b/controllers/spannerautoscaler_controller.go
@@ -569,6 +569,15 @@ func calcDesiredPURange(sa spannerv1beta1.SpannerAutoscaler) (int, int, bool) {
 	desiredMin += sa.Spec.ScaleConfig.ProcessingUnits.Min
 	desiredMax += sa.Spec.ScaleConfig.ProcessingUnits.Max
 
+	// round up, in case any schedule adds small number of PUs
+	if remainder := desiredMin % 1000; desiredMin > 1000 && remainder != 0 {
+		desiredMin = ((desiredMin / 1000) + 1) * 1000
+	}
+
+	if remainder := desiredMax % 1000; desiredMax > 1000 && remainder != 0 {
+		desiredMax = ((desiredMax / 1000) + 1) * 1000
+	}
+
 	if desiredMin != sa.Status.DesiredMinPUs || desiredMax != sa.Status.DesiredMaxPUs {
 		changed = true
 	}

--- a/main.go
+++ b/main.go
@@ -164,6 +164,10 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "SpannerAutoscaleSchedule")
 		os.Exit(exitCode)
 	}
+	if err = (&spannerv1beta1.SpannerAutoscaleSchedule{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "SpannerAutoscaleSchedule")
+		os.Exit(exitCode)
+	}
 	//+kubebuilder:scaffold:builder
 
 	setupLog.Info("starting manager")


### PR DESCRIPTION
<!--
    Please read the CLA carefully before submitting your contribution to Mercari.
    Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
    https://www.mercari.com/cla/
-->

### Contents of this PR
- Add validation webhook for `SpannerAutoscaleSchedule`, which does the following:
  - block changes to `TargetResource` and `Schedule` after resource creation
  - validate that `Schedule.Cron` and `Schedule.Duration` can be parsed correctly
  - ~validate that `Schedule.Duration` is smaller than the time period of the `Schedule.Cron` job (if this is not checked, then there can be a cascading scale-up trigger when the next cron job is run before the duration of the previous one is over)~
- Modify the implementation of the `scheduler` package so that a `schedule` is created for each `SpannerAutoscaler` instance (earlier, there was just one `scheduler` which was responsible for updating all `SpannerAutoscaler` resources)

EDIT:
- validation for schedule duration overlap has been removed because it is not easy to validate all cases of cron job trigger times beforehand.
- a patch for rounding up the PUs to 1000 has been introduced [[ref](https://github.com/mercari/spanner-autoscaler/pull/81#discussion_r843680683)]