### PR TITLE
Fix `RoleBinding` and `namespace` in samples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,10 @@ kind-cluster-create: kind ## Create a kind cluster for development
 	@if [ -z $(shell $(KIND) get clusters | grep $(KIND_CLUSTER_NAME)) ]; then \
 	  $(KIND) create cluster --name $(KIND_CLUSTER_NAME); \
 	fi
+	## Change context to use kind cluster as default
 	kubectl config use-context kind-$(KIND_CLUSTER_NAME)
+	## Install cert-manager for generating certifacetes for validation and defaulting webhooks
+	kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.yaml
 
 kind-cluster-delete: kind ## Delete the kind cluster created for development
 	@$(KIND) delete cluster --name $(KIND_CLUSTER_NAME)

--- a/config/samples/rbac/role.yaml
+++ b/config/samples/rbac/role.yaml
@@ -18,7 +18,7 @@ metadata:
   namespace: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: spanner-autoscaller-secret-reader
 subjects:
   - kind: ServiceAccount

--- a/config/samples/spanner_v1beta1_spannerautoscaler.yaml
+++ b/config/samples/spanner_v1beta1_spannerautoscaler.yaml
@@ -2,6 +2,7 @@ apiVersion: spanner.mercari.com/v1beta1
 kind: SpannerAutoscaler
 metadata:
   name: spannerautoscaler-sample-beta
+  namespace: test
 spec:
   targetInstance:
     projectId: beta-project

--- a/config/samples/spanner_v1beta1_spannerautoscaleschedule.yaml
+++ b/config/samples/spanner_v1beta1_spannerautoscaleschedule.yaml
@@ -2,6 +2,7 @@ apiVersion: spanner.mercari.com/v1beta1
 kind: SpannerAutoscaleSchedule
 metadata:
   name: spannerautoscaleschedule-sample
+  namespace: test
 spec:
   targetResource: spannerautoscaler-sample-beta
   additionalProcessingUnits: 300


### PR DESCRIPTION


<!--
    Please read the CLA carefully before submitting your contribution to Mercari.
    Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
    https://www.mercari.com/cla/
-->

## What this PR does / Why we need it
- Add `namespace` to new version samples
- Fix RoleBinding subject `kind` (the provided subject is actually a `Role` and not a `CluserRole`)
- Install cert-manager by default when Kind cluster is reset

## Which issue(s) this PR fixes

<!--
    Please specify the related issue.
    If there is no issue related to this PR, first of all you should consider creating an issue.
-->
Fixes #
