### PR TITLE
Freeze Go version for `golangci-lint`

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,7 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          ## golang v1.18 breaks golangci-lint <= v1.45
+          ## ref: https://github.com/golangci/golangci-lint/issues/2374#issuecomment-1069029422
+          go-version: '1.17'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.44.0


### PR DESCRIPTION
Latest version of Go (v1.18) breaks the golangci-lint versions <= v1.45

<!--
    Please read the CLA carefully before submitting your contribution to Mercari.
    Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
    https://www.mercari.com/cla/
-->

## What this PR does / Why we need it
Fix the version of golang to v1.17 for `golangci-lint` workflow

## Which issue(s) this PR fixes
- Broken CI runs: https://github.com/mercari/spanner-autoscaler/runs/5964529973?check_suite_focus=true
- https://github.com/golangci/golangci-lint/issues/2374#issuecomment-1069029422
<!--
    Please specify the related issue.
    If there is no issue related to this PR, first of all you should consider creating an issue.
-->

