### PR TITLE
Honor config-file options

### DIFF
--- a/controllers/spannerautoscaler_controller.go
+++ b/controllers/spannerautoscaler_controller.go
@@ -264,7 +264,7 @@ func (r *SpannerAutoscalerReconciler) Reconcile(ctx context.Context, req ctrlrec
 			return ctrlreconcile.Result{}, err
 		}
 
-		log.Info("replaced syncer", "namespaced name", sa)
+		log.Info("replaced syncer", "namespacedName", sa)
 		return ctrlreconcile.Result{}, nil
 	}
 
@@ -482,22 +482,26 @@ func (r *SpannerAutoscalerReconciler) needUpdateProcessingUnits(log logr.Logger,
 
 	switch {
 	case desiredProcessingUnits == currentProcessingUnits:
-		log.Info("no need to scale", "current-processing-units", currentProcessingUnits, "current-cpu", sa.Status.CurrentHighPriorityCPUUtilization)
+		log.Info("no need to scale", "currentPU", currentProcessingUnits, "currentCPU", sa.Status.CurrentHighPriorityCPUUtilization)
 		return false
 
 	case desiredProcessingUnits > currentProcessingUnits && r.clock.Now().Before(sa.Status.LastScaleTime.Time.Add(10*time.Second)):
 		log.Info("too short to scale up since last scale-up event",
-			"time gap", now.Sub(sa.Status.LastScaleTime.Time),
+			"timeGap", now.Sub(sa.Status.LastScaleTime.Time).String(),
 			"now", now.String(),
-			"last scale time", sa.Status.LastScaleTime,
+			"lastScaleTime", sa.Status.LastScaleTime,
+			"currentPU", currentProcessingUnits,
+			"desiredPU", desiredProcessingUnits,
 		)
 		return false
 
 	case desiredProcessingUnits < currentProcessingUnits && r.clock.Now().Before(sa.Status.LastScaleTime.Time.Add(r.scaleDownInterval)):
 		log.Info("too short to scale down since last scale-up event",
-			"time gap", now.Sub(sa.Status.LastScaleTime.Time),
+			"timeGap", now.Sub(sa.Status.LastScaleTime.Time).String(),
 			"now", now.String(),
-			"last scale time", sa.Status.LastScaleTime,
+			"lastScaleTime", sa.Status.LastScaleTime,
+			"currentPU", currentProcessingUnits,
+			"desiredPU", desiredProcessingUnits,
 		)
 		return false
 

--- a/main.go
+++ b/main.go
@@ -55,21 +55,19 @@ func init() {
 }
 
 var (
-	metricsAddr          = flag.String("metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
-	probeAddr            = flag.String("health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	metricsAddr          = flag.String("metrics-bind-address", "", "The address the metric endpoint binds to.")
+	probeAddr            = flag.String("health-probe-bind-address", "", "The address the probe endpoint binds to.")
 	enableLeaderElection = flag.Bool("leader-elect", false, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
+	leaderElectionID     = flag.String("leader-elect-id", "", "Lease name for leader election.")
 	scaleDownInterval    = flag.Duration("scale-down-interval", 55*time.Minute, "The scale down interval.")
 	configFile           = flag.String("config", "", "The controller will load its initial configuration from this file. "+
 		"Omit this flag to use the default configuration values. Command-line flags override configuration from this file.")
 )
 
 const (
-	exitCode         = 1
-	leaderElectionID = "spanner-autoscaler-leader-election"
-	healthzEndpoint  = "/healthz"
-	readyzEndpoint   = "/readyz"
-	healthzName      = "healthz"
-	readyzName       = "readyz"
+	exitCode    = 1
+	healthzName = "healthz"
+	readyzName  = "readyz"
 )
 
 func main() {
@@ -100,11 +98,9 @@ func main() {
 	options := ctrlmanager.Options{
 		Scheme:                 scheme,
 		LeaderElection:         *enableLeaderElection,
-		LeaderElectionID:       leaderElectionID,
+		LeaderElectionID:       *leaderElectionID,
 		MetricsBindAddress:     *metricsAddr,
 		HealthProbeBindAddress: *probeAddr,
-		ReadinessEndpointName:  readyzEndpoint,
-		LivenessEndpointName:   healthzEndpoint,
 
 		// TODO: remove this when `v1beta1` is stable and tested
 		// Only for development


### PR DESCRIPTION
<!--
    Please read the CLA carefully before submitting your contribution to Mercari.
    Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
    https://www.mercari.com/cla/
-->

## What this PR does / Why we need it
- rename some log keys to [common naming convention](https://pkg.go.dev/github.com/go-logr/logr#hdr-Key_Naming_Conventions)
- remove the default values for command line options
- make `leaderElectionID` configurable
- remove unnecessary `healthzEndpoin` and `readyzEndpoint` because they were default values already

## Which issue(s) this PR fixes
Currently, the parameters which have default values from the command line, can not be overridden by the config file. This PR fixes this behavior.
<!--
    Please specify the related issue.
    If there is no issue related to this PR, first of all you should consider creating an issue.
-->

