### PR TITLE
Add additional information for `scaledownStepSize`

### DIFF
--- a/docs/crd-reference.md
+++ b/docs/crd-reference.md
@@ -91,7 +91,7 @@ _Appears in:_
 | `computeType` _ComputeType_ | Whether to use `nodes` or `processing-units` for scaling. This is only used at the time of CustomResource creation. If compute capacity is provided in `nodes`, then it is automatically converted to `processing-units` at the time of resource creation, and internally, only `ProcessingUnits` are used for computations and scaling. |
 | `nodes` _[ScaleConfigNodes](#scaleconfignodes)_ | If `nodes` are provided at the time of resource creation, then they are automatically converted to `processing-units`. So it is recommended to use only the processing units. Ref: [Spanner Compute Capacity](https://cloud.google.com/spanner/docs/compute-capacity#compute_capacity) |
 | `processingUnits` _[ScaleConfigPUs](#scaleconfigpus)_ | ProcessingUnits for scaling of the Spanner instance. Ref: [Spanner Compute Capacity](https://cloud.google.com/spanner/docs/compute-capacity#compute_capacity) |
-| `scaledownStepSize` _integer_ | The maximum number of processing units which can be deleted in one scale-down operation |
+| `scaledownStepSize` _integer_ | The maximum number of processing units which can be deleted in one scale-down operation. Should be a multiple of 1000. |
 | `targetCPUUtilization` _[TargetCPUUtilization](#targetcpuutilization)_ | The CPU utilization which the autoscaling will try to achieve. Ref: [Spanner CPU utilization](https://cloud.google.com/spanner/docs/cpu-utilization#task-priority) |
 
 


### PR DESCRIPTION
<!--
    Please read the CLA carefully before submitting your contribution to Mercari.
    Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
    https://www.mercari.com/cla/
-->

## What this PR does / Why we need it
Adds additional information for scaleDownStepSize.
```diff
- | `scaledownStepSize` _integer_ | The maximum number of processing units which can be deleted in one scale-down operation
+ | `scaledownStepSize` _integer_ | The maximum number of processing units which can be deleted in one scale-down operation. Should be a multiple of 1000. |
```

## Which issue(s) this PR fixes

<!--
    Please specify the related issue.
    If there is no issue related to this PR, first of all you should consider creating an issue.
-->
~Fixes #~ Did not create an issue since it's just a doc fix. Please let me know if I should also create an issue.

I used a `scaledownStepSize` of 500, and received the following error.
```
The SpannerAutoscaler "spanner-autoscaler" is invalid
: spec.scaleConfig.scaledownStepSize: Invalid value: 500
: spec.scaleConfig.scaledownStepSize in body should be a multiple of 1000
```

This information is missing from the documentation, so I think it can save other developers using this autoscaler some time.