### PR TITLE
Add permisisons to CI for adding size labels

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -9,6 +9,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
- Attempt to fix the permissions for workflow applying size labels to PRs (maybe https://github.com/mercari/spanner-autoscaler/pull/99 PR will pass size label CI job/checks after this PR is merged)

Rationale behind this: 
> Every pull request is an issue, but not every issue is a pull request. For this reason, "shared" actions for both features, like managing assignees, labels, and milestones, are provided within the Issues endpoints. [^github-doc-ref]

[^github-doc-ref]: https://docs.github.com/en/rest/issues/labels?apiVersion=2022-11-28#about-labels