### PR TITLE
Update to `permissions.contents = write` of create git tag action

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -9,7 +9,7 @@ jobs:
   bump-tag:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     outputs:
       new_version: ${{ steps.bump-semver.outputs.new_version }}


### PR DESCRIPTION
## What this PR does / Why we need it

- SSIA
- Fix GitHub Actions configuration

## Which issue(s) this PR fixes

Fixes https://github.com/mercari/spanner-autoscaler/actions/runs/7456959858/job/20289008284

> remote: Permission to mercari/spanner-autoscaler.git denied to github-actions[bot].
> fatal: unable to access 'https://github.com/mercari/spanner-autoscaler/': The requested URL returned error: 403
