### PR TITLE
Fix goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,3 +9,4 @@ builds:
   - linux
   - darwin
   - windows
+  main: ./cmd


### PR DESCRIPTION
<!--
    Please read the CLA carefully before submitting your contribution to Mercari.
    Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
    https://www.mercari.com/cla/
-->

## What this PR does / Why we need it
Add `main.go` file location to goreleaser config

## Which issue(s) this PR fixes
- Fix [CI error](https://github.com/mercari/spanner-autoscaler/actions/runs/7485574814/job/20557106083): `error=build for spanner-autoscaler does not contain a main function`
<!--
    Please specify the related issue.
    If there is no issue related to this PR, first of all you should consider creating an issue.
-->

