### PR TITLE
Exclude dependabot PRs from release-notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,6 +4,8 @@ changelog:
   exclude:
     labels:
       - ignore-for-release-notes
+    authors:
+      - dependabot
   categories:
     - title: Breaking Changes 🛠
       labels:


### PR DESCRIPTION
SSIA

