### PR TITLE
Fix dockerfile Golang version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 as builder
+FROM golang:1 as builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
<!--
    Please read the CLA carefully before submitting your contribution to Mercari.
    Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
    https://www.mercari.com/cla/
-->

## What this PR does / Why we need it
`go.mod` has version `1.24` but dockerfile has `1.22` which causes image build failure. Therefore, use latest version in Dockerfile by default (because `go build` is backward compatible since introduction of toolchain feature).

## Which issue(s) this PR fixes

<!--
    Please specify the related issue.
    If there is no issue related to this PR, first of all you should consider creating an issue.
-->
Fixes #
