### PR TITLE
Improve local env

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,6 +17,6 @@ jobs:
         with:
           go-version-file: go.mod
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,13 @@ Dockerfile.cross
 *.swp
 *.swo
 *~
+
+# Tilt local config (use tilt_config.json.example as a template)
+tilt_config.json
+
+# GCP service account key (never commit credentials)
+service-account-key.json
+
+# Compiled emulator binaries (produced by go build)
+/main
+/monitoring-emulator

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,10 +8,10 @@ run:
   # Default value is empty list, but next dirs are always skipped independently
   # From this option's value:
   #   	vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
-  skip-dirs:
+  exclude-dirs:
     - bin
 
-  skip-files:
+  exclude-files:
     - ".*_test.go"
 
   timeout: 10m
@@ -20,8 +20,6 @@ run:
 linters-settings:
 
   govet:
-    # Report about shadowed variables
-    check-shadowing: true
 
   golint:
     # Minimal confidence for issues, default is 0.8

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,72 +1,15 @@
 # golangci-lint configuration file
 # see: https://github.com/golangci/golangci/wiki/Configuration
 
+version: "2"
+
 # Options for analysis running
 run:
-  # Which dirs to skip: they won't be analyzed;
-  # Can use regexp here: generated.*, regexp is applied on full path;
-  # Default value is empty list, but next dirs are always skipped independently
-  # From this option's value:
-  #   	vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
-  exclude-dirs:
-    - bin
-
-  exclude-files:
-    - ".*_test.go"
-
   timeout: 10m
-
-# All available settings of specific linters
-linters-settings:
-
-  govet:
-
-  golint:
-    # Minimal confidence for issues, default is 0.8
-    min-confidence: 0
-
-  gocyclo:
-    # Minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 30
-
-  dupl:
-    # Tokens count to trigger issue, 150 by default
-    threshold: 100
-
-  misspell:
-    # Correct spellings using locale preferences for US or UK.
-    # Default is to use a neutral variety of English.
-    # Setting locale to US will correct the British spelling of 'colour' to 'color'.
-    locale: US
-    # - colour
-
-  nakedret:
-    # Make an issue if func has more lines of code than this setting and it has naked returns; default is 30
-    max-func-lines: 0
-
-  gocritic:
-    # Which checks should be disabled; can't be combined with 'enabled-checks'; default is empty
-    disabled-checks:
-      - whyNoLint
-      - wrapperFunc
-      - ifElseChain
-      - paramTypeCombine
-      - singleCaseSwitch
-      - unnamedResult
-      - hugeParam
-      - octalLiteral
-      - commentedOutCode
-
-    # Enable multiple checks by tags, run `GL_DEBUG=gocritic golangci-lint` run to see all tags and checks.
-    # Empty list by default. See https://github.com/go-critic/go-critic#usage -> section "Tags".
-    enabled-tags:
-      - performance
-      - style
-      - experimental
 
 # Settings for enabling and disabling linters
 linters:
-  disable-all: true
+  default: none
   enable:
     - bodyclose
     # - depguard # disable this temporarily until we confirm and create an allow-list of the imported modules
@@ -75,41 +18,95 @@ linters:
     - errcheck
     - gocritic
     - gocyclo
-    - gofmt
-    - gofumpt
-    - goimports
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - misspell
     - nakedret
     - nolintlint
     - rowserrcheck
-    - staticcheck
-    - stylecheck
-    - typecheck
+    - staticcheck  # includes gosimple and stylecheck in golangci-lint v2
     - unconvert
     - unused
     - whitespace
+    # typecheck was removed in golangci-lint v2 (type checking is now always on)
 
-# Configuration of issue rules
-issues:
-  # Excluding configuration per-path, per-linter, per-text and per-source
-  exclude-rules:
-    # Exclude shadow checking on the variable named err
-    - text: "shadow: declaration of \"err\""
-      linters:
-        - govet
+  # All available settings of specific linters
+  settings:
+    gocyclo:
+      # Minimal code complexity to report, 30 by default (but we recommend 10-20)
+      min-complexity: 30
 
-    # Exclude godox check for TODOs, FIXMEs, and BUGs
-    - text: "Line contains TODO/BUG/FIXME:"
-      linters:
-        - godox
+    dupl:
+      # Tokens count to trigger issue, 150 by default
+      threshold: 100
 
-    # Exclude some linters from running on tests files
-    - path: _test\.go
-      linters:
-        - gocyclo
-        - goconst
+    misspell:
+      # Correct spellings using locale preferences for US or UK.
+      # Default is to use a neutral variety of English.
+      # Setting locale to US will correct the British spelling of 'colour' to 'color'.
+      locale: US
+
+    nakedret:
+      # Make an issue if func has more lines of code than this setting and it has naked returns; default is 30
+      max-func-lines: 0
+
+    gocritic:
+      # Which checks should be disabled; can't be combined with 'enabled-checks'; default is empty
+      disabled-checks:
+        - whyNoLint
+        - wrapperFunc
+        - ifElseChain
+        - paramTypeCombine
+        - singleCaseSwitch
+        - unnamedResult
+        - hugeParam
+        - octalLiteral
+        - commentedOutCode
+
+      # Enable multiple checks by tags, run `GL_DEBUG=gocritic golangci-lint` run to see all tags and checks.
+      # Empty list by default. See https://github.com/go-critic/go-critic#usage -> section "Tags".
+      enabled-tags:
+        - performance
+        - style
+        - experimental
+
+  exclusions:
+    # Exclude generated and vendor directories
+    paths:
+      - bin
+
+    rules:
+      # Exclude shadow checking on the variable named err
+      - text: "shadow: declaration of \"err\""
+        linters:
+          - govet
+
+      # Exclude godox check for TODOs, FIXMEs, and BUGs
+      - text: "Line contains TODO/BUG/FIXME:"
+        linters:
+          - godox
+
+      # Exclude some linters from running on tests files
+      - path: _test\.go
+        linters:
+          - gocyclo
+          - goconst
+          - errcheck
+          - gosec
+          - unused
+          - nolintlint
+
+      # QF1008: "could remove embedded field from selector" — pre-existing style
+      # issue across the codebase, not a correctness concern.
+      - linters:
+          - staticcheck
+        text: "QF1008:"
+
+# Formatters (gofmt/gofumpt/goimports moved from linters in golangci-lint v2)
+formatters:
+  enable:
+    - gofmt
+    - gofumpt
+    - goimports

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1 as builder
+FROM golang:1.26 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,10 @@ tilt-down: tilt kind ## Tear down Tilt, stop emulators, delete the kind cluster,
 	$(KIND) delete cluster --name $(KIND_CLUSTER_NAME)
 	rm -rf $(WEBHOOK_CERT_DIR)
 
+.PHONY: logs-controller
+logs-controller: tilt ## Stream controller logs (requires Tilt to be running).
+	$(TILT) logs -f controller
+
 .PHONY: kind-cluster-delete
 kind-cluster-delete: kind ## Delete the kind cluster created for development
 	@$(KIND) delete cluster --name $(KIND_CLUSTER_NAME)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 IMG ?= mercari/spanner-autoscaler:latest
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.26.1
+ENVTEST_K8S_VERSION = 1.32.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -15,6 +15,15 @@ endif
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
+
+# base64 decode flag differs between macOS (base64 -D) and Linux (base64 -d).
+BASE64_DECODE := $(shell if base64 --decode /dev/null 2>/dev/null; then echo "base64 --decode"; elif base64 -d /dev/null 2>/dev/null; then echo "base64 -d"; else echo "base64 -D"; fi)
+
+# Webhook TLS cert dir used by run-dev.
+WEBHOOK_CERT_DIR ?= $(LOCALBIN)/webhook-certs
+
+# Webhook server namespace (must match config/default).
+WEBHOOK_NAMESPACE ?= spanner-autoscaler
 
 .PHONY: all
 all: build
@@ -70,6 +79,35 @@ lint: golangci-lint ## Run golangci-lint against code.
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
 
+.PHONY: dev-certs
+dev-certs: ## Extract webhook TLS certs from cluster into $(WEBHOOK_CERT_DIR) for local webhook development.
+	mkdir -p $(WEBHOOK_CERT_DIR)
+	kubectl get secret -n $(WEBHOOK_NAMESPACE) webhook-server-cert -o jsonpath='{.data.tls\.crt}' | $(BASE64_DECODE) > $(WEBHOOK_CERT_DIR)/tls.crt
+	kubectl get secret -n $(WEBHOOK_NAMESPACE) webhook-server-cert -o jsonpath='{.data.tls\.key}' | $(BASE64_DECODE) > $(WEBHOOK_CERT_DIR)/tls.key
+
+.PHONY: run-dev
+run-dev: manifests generate fmt vet dev-certs ## Run controller locally with webhook forwarding (requires kind cluster with deploy-dev or tilt-up).
+	go run ./cmd/main.go -zap-devel --cert-dir=$(WEBHOOK_CERT_DIR)
+
+.PHONY: test-integration
+test-integration: manifests generate envtest ## Run integration tests (starts emulators automatically if not running).
+	@if ! nc -z localhost 9091 2>/dev/null; then \
+		echo "Emulators not running, starting..."; \
+		$(MAKE) emulator-up; \
+		echo "Waiting for monitoring emulator to be ready..."; \
+		for i in $$(seq 1 60); do nc -z localhost 9091 2>/dev/null && break || sleep 1; done; \
+	fi
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
+	go test -tags integration ./test/integration/... -v -count=1
+
+.PHONY: emulator-up
+emulator-up: ## Start Spanner and Monitoring emulators via docker-compose.
+	docker compose up -d --build
+
+.PHONY: emulator-down
+emulator-down: ## Stop and remove emulator containers.
+	docker compose down
+
 KIND_CLUSTER_NAME = spanner-autoscaler
 
 .PHONY: kind-cluster-create
@@ -77,10 +115,18 @@ kind-cluster-create: kind ## Create a kind cluster for development
 	@if [ -z $(shell $(KIND) get clusters | grep $(KIND_CLUSTER_NAME)) ]; then \
 	  $(KIND) create cluster --name $(KIND_CLUSTER_NAME); \
 	fi
-	## Change context to use kind cluster as default
 	kubectl config use-context kind-$(KIND_CLUSTER_NAME)
-	## Install cert-manager for generating certifacetes for validation and defaulting webhooks
-	kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.yaml
+
+.PHONY: tilt-up
+tilt-up: kind-cluster-create tilt ## Create kind cluster (if needed) and start Tilt.
+	$(TILT) up
+
+.PHONY: tilt-down
+tilt-down: tilt kind ## Tear down Tilt, stop emulators, delete the kind cluster, and remove webhook certs.
+	$(TILT) down
+	$(MAKE) emulator-down
+	$(KIND) delete cluster --name $(KIND_CLUSTER_NAME)
+	rm -rf $(WEBHOOK_CERT_DIR)
 
 .PHONY: kind-cluster-delete
 kind-cluster-delete: kind ## Delete the kind cluster created for development
@@ -100,8 +146,8 @@ build: manifests generate fmt vet ## Build manager binary.
 	go build -o bin/manager cmd/main.go
 
 .PHONY: run
-run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./cmd/main.go -zap-devel
+run: manifests generate fmt vet ## Run a controller from your host (webhooks disabled).
+	ENABLE_WEBHOOKS=false go run ./cmd/main.go -zap-devel
 
 # If you wish to build the manager image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64 ). However, you must enable docker buildKit for it.
@@ -174,19 +220,21 @@ KIND = $(LOCALBIN)/kind
 KPT = $(LOCALBIN)/kpt
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 CRD_REF_DOCS = $(LOCALBIN)/crd-ref-docs
+TILT = $(LOCALBIN)/tilt
 
 ## Tool Versions
-KUSTOMIZE_VERSION ?= v5.0.0
-CONTROLLER_TOOLS_VERSION ?= v0.18.0
-KIND_VERSION ?= v0.17.0
+KUSTOMIZE_VERSION ?= v5.8.1
+CONTROLLER_TOOLS_VERSION ?= v0.20.1
+KIND_VERSION ?= v0.31.0
 KPT_VERSION ?= v1.0.0-beta.34
-GOLANGCI_LINT_VERSION ?= v1.64.8
-CRD_REF_DOCS_VERSION ?= v0.1.0
+GOLANGCI_LINT_VERSION ?= v2.1.6
+CRD_REF_DOCS_VERSION ?= v0.3.0
+TILT_VERSION ?= v0.33.21
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 
 .PHONY: deps
-deps: kustomize controller-gen envtest kind kpt golangci-lint crd-ref-docs ## Download the following dependencies locally (in './bin') if necessary
+deps: kustomize controller-gen envtest kind kpt golangci-lint crd-ref-docs tilt ## Download the following dependencies locally (in './bin') if necessary
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.
@@ -210,7 +258,7 @@ $(ENVTEST): $(LOCALBIN)
 
 .PHONY: kind
 kind: ## Downlaod 'kind' locally if necessary
-	test -s $(LOCALBIN)/kind && $(LOCALBIN)/kind --version | grep -q $(CONTROLLER_TOOLS_VERSION) || \
+	test -s $(LOCALBIN)/kind && $(LOCALBIN)/kind --version | grep -q $(KIND_VERSION) || \
 	GOBIN=$(LOCALBIN) go install sigs.k8s.io/kind@$(KIND_VERSION)
 
 .PHONY: kpt
@@ -221,10 +269,20 @@ kpt: ## Downlaod 'kpt' locally if necessary
 .PHONY: golangci-lint
 golangci-lint: ## Downlaod 'golangci-lint' locally if necessary
 	test -s $(LOCALBIN)/golangci-lint && $(LOCALBIN)/golangci-lint --version | grep -q $(GOLANGCI_LINT_VERSION) || \
-	GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 .PHONY: crd-ref-docs
 crd-ref-docs: ## Downlaod 'crd-ref-docs' locally if necessary
 	test -s $(LOCALBIN)/crd-ref-docs || \
 	GOBIN=$(LOCALBIN) go install github.com/elastic/crd-ref-docs@$(CRD_REF_DOCS_VERSION)
+
+.PHONY: tilt
+tilt: $(LOCALBIN) ## Download 'tilt' locally if necessary
+	@if ! test -s $(LOCALBIN)/tilt || ! $(LOCALBIN)/tilt version | grep -q $(subst v,,$(TILT_VERSION)); then \
+		OS=$$(uname -s | tr '[:upper:]' '[:lower:]' | sed 's/darwin/mac/'); \
+		ARCH=$$(uname -m | sed 's/aarch64/arm64/'); \
+		echo "Downloading tilt $(TILT_VERSION)..."; \
+		curl -fsSL "https://github.com/tilt-dev/tilt/releases/download/$(TILT_VERSION)/tilt.$(subst v,,$(TILT_VERSION)).$${OS}.$${ARCH}.tar.gz" \
+			| tar -xz -C $(LOCALBIN) tilt; \
+	fi
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ When CPU Utilization(High Priority) is above (or below) `targetCPUUtilization`, 
 
 The [pricing of Cloud Spanner](https://cloud.google.com/spanner/pricing) states that any compute capacity which is provisioned will be billed for a minimum of one hour, so Spanner Autoscaler maintains the increased compute capacity for about an hour. Spanner Autoscaler has `--scale-down-interval` flag (default: 55min) for achieving this.
 
-While scaling down, removing large amounts of compute capacity at once (like 10000 PU -> 1000 PU) can cause a latency increase. Therefore, Spanner Autoscaler decreases the compute capacity in steps to avoid such large disruptions. This step size can be provided with the `scaledownStepSize` parameter (default: 2000 PU).
+While scaling down, removing large amounts of compute capacity at once (like 10000 PU -> 1000 PU) can cause a latency increase. Therefore, Spanner Autoscaler decreases the compute capacity in steps to avoid such large disruptions. This step size can be configured with the `scaledownStepSize` parameter (default: 2000 PU). Similarly, `scaleupStepSize` limits how much capacity can be added in a single scale-up operation (default: no limit). Both parameters accept either an integer number of Processing Units or a percentage of current capacity (e.g., `"10%"`).
 <img src="./docs/assets/node_scaledown.png" width="400" height="200">
+
+Per-resource scale intervals can also be configured with `scaledownInterval` and `scaleupInterval` in the `scaleConfig` section, overriding the global `--scale-down-interval` and `--scale-up-interval` flags set on the controller.
 
 ### Scheduled scaling feature
 
@@ -40,6 +42,8 @@ spec:
     cron: "0 2 * * *"
     duration: 3h
 ```
+
+> **Note:** `spec.targetResource` and `spec.schedule` (cron and duration) are **immutable** after creation. To change the target or schedule, delete the `SpannerAutoscaleSchedule` and create a new one. Only `spec.additionalProcessingUnits` can be updated in place.
 
 ## Installation
 
@@ -81,6 +85,30 @@ Spanner Autoscaler can be installed using [KPT](https://kpt.dev/installation/) b
 
 
 ## Examples
+
+#### With custom step sizes and per-resource intervals:
+
+```yaml
+apiVersion: spanner.mercari.com/v1beta1
+kind: SpannerAutoscaler
+metadata:
+  name: spannerautoscaler-sample
+  namespace: your-namespace
+spec:
+  targetInstance:
+    projectId: your-gcp-project-id
+    instanceId: your-spanner-instance-id
+  scaleConfig:
+    processingUnits:
+      min: 1000
+      max: 10000
+    scaledownStepSize: "20%"  # or an integer, e.g. 2000
+    scaleupStepSize: "50%"    # or an integer, e.g. 3000; defaults to no limit
+    scaledownInterval: 55m    # overrides --scale-down-interval for this resource
+    scaleupInterval: 30s      # overrides --scale-up-interval for this resource
+    targetCPUUtilization:
+      highPriority: 60
+```
 
 #### Single Service Account using Workload Identity:
 
@@ -153,6 +181,7 @@ spec:
         highPriority: 60
 ```
 
+> **Note:** `spec.targetInstance` (`projectId` and `instanceId`) is **immutable** after creation. To change the target Spanner instance, delete the `SpannerAutoscaler` and create a new one.
 
 ## GCP Setup
 
@@ -258,6 +287,15 @@ Following are some other advanced methods which can also be used for GCP authent
 ## Development and Contribution
 
 See [docs/development.md](docs/development.md) and [CONTRIBUTING.md](.github/CONTRIBUTING.md) respectively.
+
+The recommended local development workflow uses [Tilt](https://tilt.dev) with local Spanner and Cloud Monitoring emulators — no real GCP credentials required:
+
+```console
+$ make tilt-up   # creates a kind cluster and starts Tilt
+$ make tilt-down # tears everything down (Tilt, emulators, kind cluster, webhook certs)
+```
+
+Tilt automatically starts the emulators, installs cert-manager, deploys the webhook configuration, and runs the controller locally. Changes to any Go file under `cmd/`, `api/`, or `internal/` trigger a live reload. Running `make tilt-up` after `make tilt-down` starts from a completely clean state.
 
 ### :information_source: Migration from `0.3.0` to `0.4.0`:
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,138 @@
+# -*- mode: Python -*-
+
+# ── Configuration ──────────────────────────────────────────────────────────────
+# Webhooks are enabled by default because CRD field additions (which require
+# webhook changes) are frequent in this project.
+#
+# To disable webhooks (for pure controller logic development):
+#   tilt up -- --enable_webhooks=false
+# Or create tilt_config.json (gitignored) with: {"enable_webhooks": false}
+config.define_bool("enable_webhooks", args=False,
+    usage="Enable webhook support (default: true). Set false for controller-only development.")
+cfg = config.parse()
+ENABLE_WEBHOOKS = cfg.get("enable_webhooks", True)
+
+CERT_MANAGER_VERSION = "v1.14.5"
+WEBHOOK_NAMESPACE    = "spanner-autoscaler"
+CERT_NAME            = "spanner-autoscaler-serving-cert"
+WEBHOOK_CERT_DIR     = "bin/webhook-certs"
+KUSTOMIZE            = "./bin/kustomize"
+
+# ── Prerequisites ──────────────────────────────────────────────────────────────
+# Install kustomize into ./bin if not present (runs once at Tilt load time).
+local("test -f {k} || make kustomize".format(k=KUSTOMIZE), quiet=True, echo_off=True)
+
+# ── Emulators (docker-compose) ─────────────────────────────────────────────────
+# Spanner emulator (:9010 gRPC, :9011 admin) and
+# Monitoring emulator (:9090 gRPC, :9091 admin) are managed by docker-compose.
+docker_compose('./docker-compose.yml')
+
+# ── Manifest generation ────────────────────────────────────────────────────────
+# Re-runs make manifests generate when API types change.
+local_resource(
+    'generate',
+    cmd='make manifests generate',
+    deps=['api/'],
+    ignore=['**/zz_generated.*.go'],
+    labels=['setup'],
+)
+
+# ── cert-manager (webhook mode only) ──────────────────────────────────────────
+if ENABLE_WEBHOOKS:
+    local_resource(
+        'cert-manager',
+        cmd="""
+            if ! kubectl get deployment -n cert-manager cert-manager-webhook > /dev/null 2>&1; then
+                echo "Installing cert-manager {v}..."
+                kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/{v}/cert-manager.yaml
+            fi
+            kubectl wait --for=condition=available --timeout=300s -n cert-manager deployment/cert-manager
+            kubectl wait --for=condition=available --timeout=300s -n cert-manager deployment/cert-manager-webhook
+            kubectl wait --for=condition=available --timeout=300s -n cert-manager deployment/cert-manager-cainjector
+        """.format(v=CERT_MANAGER_VERSION),
+        labels=['setup'],
+    )
+
+# ── Kubernetes resources ───────────────────────────────────────────────────────
+if ENABLE_WEBHOOKS:
+    # deploy-dev overlay: scales in-cluster controller to 0 and routes
+    # webhook traffic to host.docker.internal:9443 (this machine).
+    local_resource(
+        'apply-manifests',
+        cmd=KUSTOMIZE + ' build config/deploy-dev | kubectl apply -f -',
+        deps=[
+            'config/certmanager/',
+            'config/crd/',
+            'config/default/',
+            'config/deploy-dev/',
+            'config/manager/',
+            'config/rbac/',
+            'config/webhook/',
+        ],
+        resource_deps=['generate', 'cert-manager'],
+        labels=['setup'],
+    )
+else:
+    # No-webhook mode: apply CRDs only.
+    k8s_yaml(local(KUSTOMIZE + ' build config/crd'))
+
+# ── Webhook certificates ───────────────────────────────────────────────────────
+if ENABLE_WEBHOOKS:
+    local_resource(
+        'dev-certs',
+        cmd="""
+            kubectl wait --for=condition=ready \
+                certificate/{cert} \
+                -n {ns} --timeout=120s
+            make dev-certs
+        """.format(cert=CERT_NAME, ns=WEBHOOK_NAMESPACE),
+        labels=['setup'],
+        resource_deps=['apply-manifests'],
+    )
+
+# ── Controller ─────────────────────────────────────────────────────────────────
+EMULATOR_FLAGS = '--spanner-endpoint=localhost:9010 --metrics-endpoint=localhost:9090'
+
+# ── Emulator instance setup ────────────────────────────────────────────────────
+# Create the beta-instance in the Spanner emulator and apply the local sample
+# SpannerAutoscaler resource after emulators are ready.
+local_resource(
+    'setup-emulator-instance',
+    cmd="""
+        until curl -sf -X PUT http://localhost:9011/instances/beta-project/beta-instance \
+            -H 'Content-Type: application/json' \
+            -d '{"processing_units": 1000}' > /dev/null; do sleep 1; done
+    """,
+    resource_deps=['spanner-emulator'],
+    labels=['setup'],
+)
+
+sample_deps = ['controller', 'setup-emulator-instance']
+local_resource(
+    'apply-sample',
+    cmd="""
+        until kubectl apply -f config/samples/spanner_v1beta1_spannerautoscaler_local.yaml 2>&1; do
+            echo 'Waiting for webhook to be ready...'
+            sleep 3
+        done
+    """,
+    deps=['config/samples/spanner_v1beta1_spannerautoscaler_local.yaml'],
+    resource_deps=sample_deps,
+    labels=['setup'],
+)
+
+if ENABLE_WEBHOOKS:
+    local_resource(
+        'controller',
+        serve_cmd='go run ./cmd/main.go -zap-devel --cert-dir={} {}'.format(WEBHOOK_CERT_DIR, EMULATOR_FLAGS),
+        deps=['cmd/', 'api/', 'internal/'],
+        resource_deps=['dev-certs'],
+        labels=['controller'],
+    )
+else:
+    local_resource(
+        'controller',
+        serve_cmd='ENABLE_WEBHOOKS=false go run ./cmd/main.go -zap-devel {}'.format(EMULATOR_FLAGS),
+        deps=['cmd/', 'api/', 'internal/'],
+        labels=['controller'],
+    )

--- a/api/v1alpha1/spannerautoscaler_conversion.go
+++ b/api/v1alpha1/spannerautoscaler_conversion.go
@@ -95,7 +95,7 @@ func (src *SpannerAutoscaler) ConvertTo(dstRaw conversion.Hub) error {
 	return nil
 }
 
-//nolint:stylecheck,gosec
+//nolint:gosec
 func (dst *SpannerAutoscaler) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1beta1.SpannerAutoscaler)
 	log.V(2).Info("begin conversion from v1beta1 to v1alpha1", "src", src)

--- a/api/v1beta1/spannerautoscaleschedule_webhook_test.go
+++ b/api/v1beta1/spannerautoscaleschedule_webhook_test.go
@@ -1,0 +1,111 @@
+package v1beta1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("SpannerAutoscaleSchedule validation", func() {
+	var (
+		schedule  *SpannerAutoscaleSchedule
+		namespace string
+	)
+
+	BeforeEach(func() {
+		namespace = "default"
+		schedule = &SpannerAutoscaleSchedule{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-schedule-",
+				Namespace:    namespace,
+			},
+			Spec: SpannerAutoscaleScheduleSpec{
+				TargetResource: "spannerautoscaler-sample",
+				Schedule: Schedule{
+					Cron:     "0 9 * * 1-5",
+					Duration: "1h",
+				},
+				AdditionalProcessingUnits: 500,
+			},
+		}
+	})
+
+	Describe("ValidateCreate", func() {
+		Context("with a valid cron and duration", func() {
+			It("should succeed", func() {
+				Expect(k8sClient.Create(ctx, schedule)).To(Succeed())
+				k8sClient.Delete(ctx, schedule) //nolint:errcheck
+			})
+		})
+
+		Context("with an invalid cron expression", func() {
+			BeforeEach(func() {
+				schedule.Spec.Schedule.Cron = "not-a-cron"
+			})
+
+			It("should return a validation error", func() {
+				err := k8sClient.Create(ctx, schedule)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("spec.schedule.cron"))
+			})
+		})
+
+		Context("with an invalid duration", func() {
+			BeforeEach(func() {
+				schedule.Spec.Schedule.Duration = "not-a-duration"
+			})
+
+			It("should return a validation error", func() {
+				err := k8sClient.Create(ctx, schedule)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("spec.schedule.duration"))
+			})
+		})
+	})
+
+	Describe("ValidateUpdate", func() {
+		var created *SpannerAutoscaleSchedule
+
+		BeforeEach(func() {
+			created = schedule.DeepCopy()
+			Expect(k8sClient.Create(ctx, created)).To(Succeed())
+
+			var got SpannerAutoscaleSchedule
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Namespace: created.Namespace,
+				Name:      created.Name,
+			}, &got)).To(Succeed())
+			created = &got
+		})
+
+		AfterEach(func() {
+			k8sClient.Delete(ctx, created) //nolint:errcheck
+		})
+
+		Context("when targetResource is changed", func() {
+			It("should return a validation error", func() {
+				created.Spec.TargetResource = "other-autoscaler"
+				err := k8sClient.Update(ctx, created)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("targetResource"))
+			})
+		})
+
+		Context("when schedule is changed", func() {
+			It("should return a validation error", func() {
+				created.Spec.Schedule.Cron = "0 10 * * 1-5"
+				err := k8sClient.Update(ctx, created)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("schedule"))
+			})
+		})
+
+		Context("when only additionalProcessingUnits is changed", func() {
+			It("should succeed", func() {
+				created.Spec.AdditionalProcessingUnits = 1000
+				Expect(k8sClient.Update(ctx, created)).To(Succeed())
+			})
+		})
+	})
+})

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -61,6 +61,9 @@ var (
 	leaderElectionID     = flag.String("leader-elect-id", "", "Lease name for leader election.")
 	scaleDownInterval    = flag.Duration("scale-down-interval", 55*time.Minute, "The scale down interval.")
 	scaleUpInterval      = flag.Duration("scale-up-interval", 60*time.Second, "The scale up interval.")
+	certDir              = flag.String("cert-dir", "", "Directory containing TLS certificates for the webhook server. Used for local development with webhook forwarding (see docs/development.md).")
+	spannerEndpoint      = flag.String("spanner-endpoint", "", "Override the Spanner API endpoint (e.g. localhost:9010 for the emulator).")
+	metricsEndpoint      = flag.String("metrics-endpoint", "", "Override the Cloud Monitoring API endpoint (e.g. localhost:9090 for the emulator).")
 	configFile           = flag.String("config", "", "The controller will load its initial configuration from this file. "+
 		"Omit this flag to use the default configuration values. Command-line flags override configuration from this file.")
 )
@@ -103,10 +106,7 @@ func main() {
 		LeaderElectionID:       *leaderElectionID,
 		MetricsBindAddress:     *metricsAddr,
 		HealthProbeBindAddress: *probeAddr,
-
-		// TODO: remove this when `v1beta1` is stable and tested
-		// Only for development
-		// CertDir: "./bin/dummytls",
+		CertDir:                *certDir,
 	}
 	if *configFile != "" {
 		// TODO: discussion thread for deprecating `ComponentConfig`: https://github.com/kubernetes-sigs/controller-runtime/issues/895, move to some alternatives when a conclusion is reached
@@ -133,23 +133,28 @@ func main() {
 		os.Exit(exitCode)
 	}
 
+	reconcilerOpts := []controller.Option{
+		controller.WithLog(log),
+		controller.WithScaleDownInterval(*scaleDownInterval),
+		controller.WithScaleUpInterval(*scaleUpInterval),
+	}
+	if *spannerEndpoint != "" {
+		reconcilerOpts = append(reconcilerOpts, controller.WithSpannerEndpoint(*spannerEndpoint))
+	}
+	if *metricsEndpoint != "" {
+		reconcilerOpts = append(reconcilerOpts, controller.WithMetricsEndpoint(*metricsEndpoint))
+	}
+
 	sar := controller.NewSpannerAutoscalerReconciler(
 		mgr.GetClient(),
 		mgr.GetAPIReader(),
 		mgr.GetScheme(),
 		mgr.GetEventRecorderFor("spannerautoscaler-controller"),
 		log,
-		controller.WithLog(log),
-		controller.WithScaleDownInterval(*scaleDownInterval),
-		controller.WithScaleUpInterval(*scaleUpInterval),
+		reconcilerOpts...,
 	)
 	if err := sar.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SpannerAutoscaler")
-		os.Exit(exitCode)
-	}
-
-	if err = (&spannerv1beta1.SpannerAutoscaler{}).SetupWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "SpannerAutoscaler")
 		os.Exit(exitCode)
 	}
 
@@ -164,9 +169,18 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "SpannerAutoscaleSchedule")
 		os.Exit(exitCode)
 	}
-	if err = (&spannerv1beta1.SpannerAutoscaleSchedule{}).SetupWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "SpannerAutoscaleSchedule")
-		os.Exit(exitCode)
+
+	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
+		if err = (&spannerv1beta1.SpannerAutoscaler{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "SpannerAutoscaler")
+			os.Exit(exitCode)
+		}
+		if err = (&spannerv1beta1.SpannerAutoscaleSchedule{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "SpannerAutoscaleSchedule")
+			os.Exit(exitCode)
+		}
+	} else {
+		setupLog.Info("webhooks disabled (ENABLE_WEBHOOKS=false)")
 	}
 	//+kubebuilder:scaffold:builder
 

--- a/cmd/monitoring-emulator/Dockerfile
+++ b/cmd/monitoring-emulator/Dockerfile
@@ -1,0 +1,24 @@
+FROM golang:1.26 AS builder
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /workspace
+COPY go.mod go.mod
+COPY go.sum go.sum
+RUN go mod download
+
+COPY cmd/ cmd/
+COPY api/ api/
+COPY internal/ internal/
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
+    go build -a -o monitoring-emulator ./cmd/monitoring-emulator
+
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=builder /workspace/monitoring-emulator .
+USER 65532:65532
+
+EXPOSE 9090 9091
+
+ENTRYPOINT ["/monitoring-emulator"]

--- a/cmd/monitoring-emulator/main.go
+++ b/cmd/monitoring-emulator/main.go
@@ -54,7 +54,7 @@ func main() {
 			logger.Error("failed to create spanner admin client", "error", err)
 			os.Exit(1)
 		}
-		defer spannerAdminClient.Close()
+		defer spannerAdminClient.Close() //nolint:errcheck
 	} else {
 		logger.Info("dynamic mode disabled: SPANNER_EMULATOR_HOST not set")
 	}
@@ -65,7 +65,7 @@ func main() {
 	grpcLis, err := net.Listen("tcp", ":"+grpcPort)
 	if err != nil {
 		logger.Error("failed to listen for gRPC", "port", grpcPort, "error", err)
-		os.Exit(1)
+		os.Exit(1) //nolint:gocritic
 	}
 	grpcSrv := grpc.NewServer()
 	monitoringpb.RegisterMetricServiceServer(grpcSrv, srv)
@@ -79,7 +79,7 @@ func main() {
 
 	// Start HTTP admin server.
 	adminHandler := monitoringemulator.NewAdminHandler(staticStore, workloadStore, scenarioStore)
-	adminSrv := &http.Server{
+	adminSrv := &http.Server{ //nolint:gosec
 		Addr:    ":" + adminPort,
 		Handler: adminHandler,
 	}

--- a/cmd/monitoring-emulator/main.go
+++ b/cmd/monitoring-emulator/main.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+
+	monitoringpb "cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
+	spanneradmin "cloud.google.com/go/spanner/admin/instance/apiv1"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/mercari/spanner-autoscaler/internal/monitoringemulator"
+)
+
+func main() {
+	grpcPort := envOrDefault("GRPC_PORT", "9090")
+	adminPort := envOrDefault("ADMIN_PORT", "9091")
+	spannerEmulatorHost := os.Getenv("SPANNER_EMULATOR_HOST")
+	scenarioFile := os.Getenv("SCENARIO_FILE")
+
+	logger := slog.Default()
+
+	staticStore := monitoringemulator.NewStaticStore()
+	workloadStore := monitoringemulator.NewWorkloadStore()
+	scenarioStore := monitoringemulator.NewScenarioStore()
+
+	if scenarioFile != "" {
+		if err := scenarioStore.LoadFile(scenarioFile); err != nil {
+			logger.Error("failed to load scenario file", "path", scenarioFile, "error", err)
+			os.Exit(1)
+		}
+		logger.Info("scenario file loaded", "path", scenarioFile)
+	}
+
+	// Create Spanner Admin client for dynamic (workload) mode.
+	// Only available when SPANNER_EMULATOR_HOST is set.
+	var spannerAdminClient *spanneradmin.InstanceAdminClient
+	if spannerEmulatorHost != "" {
+		logger.Info("dynamic mode enabled", "spanner_emulator_host", spannerEmulatorHost)
+		var err error
+		spannerAdminClient, err = spanneradmin.NewInstanceAdminClient(
+			context.Background(),
+			option.WithEndpoint(spannerEmulatorHost),
+			option.WithoutAuthentication(),
+			option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+		)
+		if err != nil {
+			logger.Error("failed to create spanner admin client", "error", err)
+			os.Exit(1)
+		}
+		defer spannerAdminClient.Close()
+	} else {
+		logger.Info("dynamic mode disabled: SPANNER_EMULATOR_HOST not set")
+	}
+
+	srv := monitoringemulator.NewMetricServiceServer(staticStore, workloadStore, scenarioStore, spannerAdminClient)
+
+	// Start gRPC server.
+	grpcLis, err := net.Listen("tcp", ":"+grpcPort)
+	if err != nil {
+		logger.Error("failed to listen for gRPC", "port", grpcPort, "error", err)
+		os.Exit(1)
+	}
+	grpcSrv := grpc.NewServer()
+	monitoringpb.RegisterMetricServiceServer(grpcSrv, srv)
+
+	go func() {
+		logger.Info("gRPC server listening", "port", grpcPort)
+		if err := grpcSrv.Serve(grpcLis); err != nil {
+			logger.Error("gRPC server error", "error", err)
+		}
+	}()
+
+	// Start HTTP admin server.
+	adminHandler := monitoringemulator.NewAdminHandler(staticStore, workloadStore, scenarioStore)
+	adminSrv := &http.Server{
+		Addr:    ":" + adminPort,
+		Handler: adminHandler,
+	}
+	go func() {
+		logger.Info("admin HTTP server listening", "port", adminPort)
+		if err := adminSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			logger.Error("admin HTTP server error", "error", err)
+		}
+	}()
+
+	// Wait for SIGINT or SIGTERM.
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	sig := <-quit
+	logger.Info("shutting down", "signal", sig)
+
+	grpcSrv.GracefulStop()
+	if err := adminSrv.Shutdown(context.Background()); err != nil {
+		logger.Error("admin server shutdown error", "error", err)
+	}
+}
+
+func envOrDefault(key, defaultVal string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return defaultVal
+}

--- a/cmd/spanner-emulator/Dockerfile
+++ b/cmd/spanner-emulator/Dockerfile
@@ -1,0 +1,24 @@
+FROM golang:1.26 AS builder
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /workspace
+COPY go.mod go.mod
+COPY go.sum go.sum
+RUN go mod download
+
+COPY cmd/ cmd/
+COPY api/ api/
+COPY internal/ internal/
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
+    go build -a -o spanner-emulator ./cmd/spanner-emulator
+
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=builder /workspace/spanner-emulator .
+USER 65532:65532
+
+EXPOSE 9010
+
+ENTRYPOINT ["/spanner-emulator"]

--- a/cmd/spanner-emulator/main.go
+++ b/cmd/spanner-emulator/main.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+
+	instancepb "cloud.google.com/go/spanner/admin/instance/apiv1/instancepb"
+	"google.golang.org/grpc"
+
+	"github.com/mercari/spanner-autoscaler/internal/spanneremulator"
+)
+
+func main() {
+	grpcPort := envOrDefault("GRPC_PORT", "9010")
+	adminPort := envOrDefault("ADMIN_PORT", "9011")
+
+	logger := slog.Default()
+
+	srv := spanneremulator.NewServer()
+
+	// Start gRPC server.
+	grpcLis, err := net.Listen("tcp", ":"+grpcPort)
+	if err != nil {
+		logger.Error("failed to listen for gRPC", "port", grpcPort, "error", err)
+		os.Exit(1)
+	}
+	grpcSrv := grpc.NewServer()
+	instancepb.RegisterInstanceAdminServer(grpcSrv, srv)
+
+	go func() {
+		logger.Info("gRPC server listening", "port", grpcPort)
+		if err := grpcSrv.Serve(grpcLis); err != nil {
+			logger.Error("gRPC server error", "error", err)
+		}
+	}()
+
+	// Start HTTP admin server.
+	adminSrv := &http.Server{
+		Addr:    ":" + adminPort,
+		Handler: spanneremulator.NewAdminHandler(srv),
+	}
+	go func() {
+		logger.Info("admin HTTP server listening", "port", adminPort)
+		if err := adminSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			logger.Error("admin HTTP server error", "error", err)
+		}
+	}()
+
+	// Wait for SIGINT or SIGTERM.
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	sig := <-quit
+	logger.Info("shutting down", "signal", sig)
+
+	grpcSrv.GracefulStop()
+	if err := adminSrv.Shutdown(context.Background()); err != nil {
+		logger.Error("admin server shutdown error", "error", err)
+	}
+}
+
+func envOrDefault(key, defaultVal string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return defaultVal
+}

--- a/cmd/spanner-emulator/main.go
+++ b/cmd/spanner-emulator/main.go
@@ -40,7 +40,7 @@ func main() {
 	}()
 
 	// Start HTTP admin server.
-	adminSrv := &http.Server{
+	adminSrv := &http.Server{ //nolint:gosec
 		Addr:    ":" + adminPort,
 		Handler: spanneremulator.NewAdminHandler(srv),
 	}

--- a/config/crd/bases/spanner.mercari.com_spannerautoscalers.yaml
+++ b/config/crd/bases/spanner.mercari.com_spannerautoscalers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: spannerautoscalers.spanner.mercari.com
 spec:
   group: spanner.mercari.com
@@ -387,7 +387,7 @@ spec:
                     default: 0
                     description: |-
                       The maximum number of processing units which can be added in one scale-up operation. It can be a multiple of 100 for values < 1000, or a multiple of 1000 otherwise.
-                      It can also be a percentage of the total number of processing units at the start of the scale-down operation.
+                      It can also be a percentage of the total number of processing units at the start of the scale-up operation.
                     x-kubernetes-int-or-string: true
                   targetCPUUtilization:
                     description: 'The CPU utilization which the autoscaling will try

--- a/config/crd/bases/spanner.mercari.com_spannerautoscaleschedules.yaml
+++ b/config/crd/bases/spanner.mercari.com_spannerautoscaleschedules.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: spannerautoscaleschedules.spanner.mercari.com
 spec:
   group: spanner.mercari.com

--- a/config/deploy-dev/kustomization.yaml
+++ b/config/deploy-dev/kustomization.yaml
@@ -9,7 +9,7 @@ patches:
   patch: |-
     - op: add
       path: /spec/dnsNames/0
-      value: dummy.local
+      value: host.docker.internal
 - target:
     version: v1
     kind: Deployment
@@ -27,7 +27,7 @@ patches:
       path: /spec
       value:
         type: ExternalName
-        externalName: dummy.local
+        externalName: host.docker.internal
 - target:
     version: v1
     kind: CustomResourceDefinition

--- a/config/samples/spanner_v1beta1_spannerautoscaler_local.yaml
+++ b/config/samples/spanner_v1beta1_spannerautoscaler_local.yaml
@@ -1,0 +1,24 @@
+# Local development sample for use with the emulators (make tilt-up).
+#
+# The monitoring emulator runs the default scenario (scenarios/default.yaml)
+# which simulates load at 1000 PU and expects the controller to scale up/down.
+#
+# Authentication is set to ADC; the Spanner and Monitoring emulators do not
+# perform real auth checks, so no credentials are needed.
+apiVersion: spanner.mercari.com/v1beta1
+kind: SpannerAutoscaler
+metadata:
+  name: spannerautoscaler-sample-beta
+  namespace: spanner-autoscaler
+spec:
+  targetInstance:
+    projectId: beta-project
+    instanceId: beta-instance
+  authentication:
+    type: adc
+  scaleConfig:
+    processingUnits:
+      min: 100
+      max: 10000
+    targetCPUUtilization:
+      highPriority: 40

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  spanner-emulator:
+    build:
+      context: .
+      dockerfile: cmd/spanner-emulator/Dockerfile
+    ports:
+      - "9010:9010"  # gRPC (InstanceAdmin)
+      - "9011:9011"  # HTTP admin API
+
+  monitoring-emulator:
+    build:
+      context: .
+      dockerfile: cmd/monitoring-emulator/Dockerfile
+    ports:
+      - "9090:9090"  # gRPC (MetricService)
+      - "9091:9091"  # HTTP admin API
+    environment:
+      - SPANNER_EMULATOR_HOST=spanner-emulator:9010
+      - SCENARIO_FILE=${SCENARIO_FILE:-/scenarios/default.yaml}
+    volumes:
+      - ./scenarios:/scenarios:ro
+    depends_on:
+      - spanner-emulator

--- a/docs/development.md
+++ b/docs/development.md
@@ -42,6 +42,14 @@ This runs the following steps in order:
 
 After `make tilt-down`, running `make tilt-up` starts from a completely clean state.
 
+To stream the controller logs while Tilt is running:
+
+```console
+$ make logs-controller
+```
+
+This runs `tilt logs -f controller` and follows the output until interrupted with `Ctrl-C`.
+
 ### What Tilt manages
 
 | Component | Details |

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,53 +1,317 @@
-# Development (when webhooks are enabled)
+# Development
 
-This doc explains how to setup a local environment for development and testing of the spanner-autoscaler and the spanner-autoscale-schedule controllers. Since there are conversion, validation and mutation webhooks enabled for some CRDs, we need to perform some additional steps to ensure that k8s can communicate with our webhook servers correctly.
+This doc explains how to set up a local environment for development and testing of the spanner-autoscaler and the spanner-autoscale-schedule controllers.
 
-The default approach is to:
-1. make any desired chagnes to the code
-1. build and deploy the docker image and the CRDs:
-   ```console
-   $ make kind-cluster-reset
-   $ export IMG=mercari/spanner-autoscaler:local
-   $ make docker-build kind-load-docker-image
-   $ make install deploy
-   $ kubectl apply -k config/samples
-   ```
-If there are any errors in the conversion or the validation of the sample CRs, then the `kubectl apply` command above, will fail with the corresponding errors.
+## Tilt (recommended for active development)
 
-While this approach is useful, it is very time consuming for testing minor changes in real time during development (because `make docker-build` step takes a very long time sometimes). Thus, during development, it is preferable to run the controller and the webhooks locally (since they are all part of the same binary), and forward any requests for these components from the k8s cluster to the locally running server.
+[Tilt](https://tilt.dev) automates the full local development loop: it watches your source files, rebuilds the controller, and restarts it automatically on every change. It also manages local emulators for Spanner and Cloud Monitoring so no real GCP credentials are required.
 
-This can be achieved in the following way:
-1. Modify your `/etc/hosts` to add a DNS record for your LAN IP (by adding `192.168.<your-lan-ip> dummy.local` to the `/etc/hosts` file)
-1. Deploy the CRDs and the other resources to the kind cluster:
+### Prerequisites
+
+- [Tilt](https://docs.tilt.dev/install.html) (`brew install tilt` on macOS)
+- [kind](https://kind.sigs.k8s.io/) and [kubectl](https://kubernetes.io/docs/tasks/tools/)
+- Docker (for emulators via docker-compose)
+
+> **Tip:** Run `make deps` to install all development tools (`kustomize`, `controller-gen`, `kind`, `golangci-lint`, `crd-ref-docs`, `tilt`, etc.) into `./bin`.
+
+### Usage
+
+```console
+# First time (or after make tilt-down): create a kind cluster and start Tilt
+$ make tilt-up
+
+# Subsequent runs (cluster already exists)
+$ tilt up
+```
+
+`make tilt-up` creates a kind cluster if one does not already exist and then runs `tilt up`. Tilt opens a browser UI showing the status of each component. When you edit any Go file under `cmd/`, `api/`, or `internal/`, the controller restarts automatically.
+
+Press `Ctrl-C` to stop Tilt while keeping the cluster and emulators alive (useful for a quick restart).
+
+To tear everything down completely — Tilt resources, emulators, kind cluster, and webhook certs:
+
+```console
+$ make tilt-down
+```
+
+This runs the following steps in order:
+1. `tilt down` — removes all Kubernetes resources Tilt applied
+2. `make emulator-down` — stops the docker-compose emulators
+3. Deletes the kind cluster
+4. Removes `bin/webhook-certs/`
+
+After `make tilt-down`, running `make tilt-up` starts from a completely clean state.
+
+### What Tilt manages
+
+| Component | Details |
+|---|---|
+| Spanner emulator | Started via docker-compose (gRPC :9010, admin :9011) |
+| Monitoring emulator | Started via docker-compose (gRPC :9090, admin :9091) |
+| Emulator instance | `beta-project/beta-instance` created in the Spanner emulator automatically |
+| cert-manager | Installed in the kind cluster on first run (skipped if already present) |
+| CRDs + webhook config | Applied via `config/deploy-dev` kustomize overlay |
+| TLS certificates | Extracted from the cluster and written to `bin/webhook-certs/` |
+| Controller | Runs as a local process connected to the emulators; auto-restarts on file change |
+| Sample resource | `config/samples/spanner_v1beta1_spannerautoscaler_local.yaml` applied automatically |
+
+### Emulators
+
+Both emulators are managed by `docker-compose.yml` and start automatically with `make tilt-up` (or `make emulator-up`). The controller connects to them via `--spanner-endpoint=localhost:9010` and `--metrics-endpoint=localhost:9090`, which the Tiltfile passes automatically.
+
+To manage the emulators independently:
+
+```console
+$ make emulator-up    # start
+$ make emulator-down  # stop
+```
+
+#### Spanner emulator
+
+The standard [Google Cloud Spanner emulator](https://cloud.google.com/spanner/docs/emulator) runs on:
+
+| Port | Protocol | Purpose |
+|---|---|---|
+| 9010 | gRPC | Spanner API (used by the controller) |
+| 9011 | HTTP | Admin API (instance management) |
+
+Although the Spanner emulator supports the full Spanner API, spanner-autoscaler only uses two RPC methods from the [Instance Admin API](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.admin.instance.v1):
+
+| RPC | Used in | Purpose |
+|---|---|---|
+| `InstanceAdmin.GetInstance` | `spanner.Client.GetInstance`, `spanner.Client.UpdateInstance` | Read current processing units and instance state |
+| `InstanceAdmin.UpdateInstance` | `spanner.Client.UpdateInstance` | Update `processing_units` (only this field is sent in the field mask) |
+
+Spanner instances must be created via the admin HTTP API before the controller can use them. Tilt does this automatically via the `setup-emulator-instance` resource, but you can also do it manually:
+
+```console
+# Create an instance
+$ curl -X PUT http://localhost:9011/instances/beta-project/beta-instance \
+    -H 'Content-Type: application/json' \
+    -d '{"processing_units": 1000}'
+```
+
+#### Monitoring emulator
+
+The Monitoring emulator is a **custom implementation** (not the official GCP emulator) that partially simulates the [Cloud Monitoring API](https://cloud.google.com/monitoring/api/ref_v3/rest). It runs on:
+
+| Port | Protocol | Purpose |
+|---|---|---|
+| 9090 | gRPC | Cloud Monitoring API (used by the controller) |
+| 9091 | HTTP | Admin API (configure CPU metrics) |
+
+spanner-autoscaler calls only one RPC method from the [MetricService API](https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.timeSeries/list):
+
+| RPC | Used in | Purpose |
+|---|---|---|
+| `MetricService.ListTimeSeries` | `metrics.Client.GetInstanceMetrics` | Fetch `spanner.googleapis.com/instance/cpu/utilization_by_priority` (priority=`high`) for the target instance |
+
+All other `MetricService` methods (`CreateTimeSeries`, `ListMetricDescriptors`, etc.) are **not implemented** and return `Unimplemented`.
+
+It supports three modes, checked in priority order:
+
+**1. Scenario mode** (priority 1 — default when `SCENARIO_FILE` is set)
+
+Steps through a time-based sequence of CPU values that loops indefinitely. This is the default for `make tilt-up`, which loads `scenarios/default.yaml`. It demonstrates a full scale-up → stable → scale-down cycle without any manual intervention.
+
+Scenario files are written in YAML. Each step uses either a fixed `cpu_utilization` or a `workload` (which computes CPU dynamically based on current PU — see workload mode below):
+
+```yaml
+# scenarios/default.yaml
+instances:
+  - project: beta-project
+    instance: beta-instance
+    steps:
+      - duration: 60s
+        workload:
+          cpu_utilization: 0.80
+          reference_processing_units: 1000
+      - duration: 60s
+        cpu_utilization: 0.15
+```
+
+A scenario can also be set or replaced at runtime via the admin API:
+
+```console
+$ curl -X PUT http://localhost:9091/scenario/beta-project/beta-instance \
+    -H 'Content-Type: application/json' \
+    -d '{"steps": [{"duration": "30s", "cpu_utilization": 0.8}, {"duration": "30s", "cpu_utilization": 0.1}]}'
+
+# Remove the scenario
+$ curl -X DELETE http://localhost:9091/scenario/beta-project/beta-instance
+```
+
+**2. Workload mode** (priority 2)
+
+Models real Cloud Spanner behaviour: CPU decreases proportionally when processing units increase.
+
+```
+cpu = (reference_cpu × reference_pu) / current_pu
+```
+
+Requires `SPANNER_EMULATOR_HOST` to be set (already configured in `docker-compose.yml`) so the emulator can query the current PU count from the Spanner emulator.
+
+```console
+# Set workload: 80% CPU at 1000 PU baseline
+$ curl -X PUT http://localhost:9091/workload/beta-project/beta-instance \
+    -H 'Content-Type: application/json' \
+    -d '{"cpu_utilization": 0.80, "reference_processing_units": 1000}'
+
+# Remove
+$ curl -X DELETE http://localhost:9091/workload/beta-project/beta-instance
+```
+
+**3. Static mode** (priority 3)
+
+Returns a fixed CPU utilization value regardless of current processing units. Useful for targeted testing of a specific threshold.
+
+```console
+# Set CPU to 75%
+$ curl -X PUT http://localhost:9091/metrics/beta-project/beta-instance \
+    -H 'Content-Type: application/json' \
+    -d '{"cpu_utilization": 0.75}'
+
+# Check current value
+$ curl http://localhost:9091/metrics/beta-project/beta-instance
+
+# Remove
+$ curl -X DELETE http://localhost:9091/metrics/beta-project/beta-instance
+```
+
+If no mode is configured for an instance, the controller logs `no such spanner instance metrics` and skips scaling for that cycle.
+
+### Webhook mode (default)
+
+Webhooks are **enabled by default** because CRD field additions — which also require webhook changes — happen frequently in this project. cert-manager is installed automatically on the first `tilt up` (takes ~1–2 minutes). Subsequent runs skip the install and start in seconds.
+
+### Controller-only mode (no webhooks)
+
+When working on pure scaling logic or metrics without changing any CRD fields:
+
+```console
+$ tilt up -- --enable_webhooks=false
+```
+
+Or create a `tilt_config.json` file (gitignored):
+
+```json
+{"enable_webhooks": false}
+```
+
+This skips cert-manager, webhook config, and TLS certificate setup entirely.
+
+---
+
+## Quick start (no webhooks)
+
+For most controller development (scaling logic, metrics, etc.), webhooks are not needed. `make run` disables them automatically:
+
+```console
+$ make run
+```
+
+This is the fastest way to iterate. No kind cluster or TLS certificates required — just a kubeconfig pointing to any cluster with the CRDs installed.
+
+To install CRDs into a cluster:
+
+```console
+$ make kind-cluster-reset  # create a kind cluster
+$ make install             # install CRDs
+$ kubectl apply -k config/samples
+```
+
+## Local webhook development (without Tilt)
+
+If you prefer not to use Tilt, you can run the full webhook development loop manually:
+
+1. Create (or reset) a kind cluster and deploy the dev overlay:
    ```console
    $ make kind-cluster-reset
    $ make deploy-dev
    ```
-1. Save the TLS certificates which the local server can use:
+   This deploys all CRDs and resources, scales the in-cluster controller to 0, and routes webhook traffic to `host.docker.internal:9443` (your local machine).
+
+1. Run the controller locally with webhook forwarding:
    ```console
-   $ mkdir bin/dummytls
-   $ kubectl get secret -n spanner-autoscaler webhook-server-cert -o yaml | yq e '.data."tls.crt"' - | base64 -d > bin/dummytls/tls.crt
-   $ kubectl get secret -n spanner-autoscaler webhook-server-cert -o yaml | yq e '.data."tls.key"' - | base64 -d > bin/dummytls/tls.key
+   $ make run-dev
    ```
-   Make changes in `main.go` to use these local certificates:
-   ```diff
-    mgr, err := ctrlmanager.New(cfg, ctrlmanager.Options{
-      Scheme:                 scheme,
-      LeaderElection:         *enableLeaderElection,
-      LeaderElectionID:       leaderElectionID,
-      MetricsBindAddress:     *metricsAddr,
-      HealthProbeBindAddress: *probeAddr,
-      ReadinessEndpointName:  readyzEndpoint,
-      LivenessEndpointName:   healthzEndpoint,
-    
-   +  // TODO: remove this when `v1beta1` is stable and tested
-   +  // Only for development
-   +  CertDir: "./bin/dummytls",
-    })
+   `run-dev` automatically extracts the webhook TLS certificate from the cluster into `bin/webhook-certs/` and starts the controller with `--cert-dir` pointing to that directory.
+
+1. Apply sample resources:
+   ```console
+   $ kubectl apply -k config/samples
    ```
-1. Continue with development and testing by running the local server with `make run` command. To test any new changes, make the desired changes, stop the controller with `Ctrl-C` and then run `make run` again.
 
-This will deploy the CRDs and other resources to the cluster, but will forward any controller or webhook related requests from k8s cluster to our locally running controller.
+1. To test further changes, stop the controller (`Ctrl-C`) and run `make run-dev` again. The certs are re-extracted on each invocation (in case they were rotated).
 
-### Things to take care before sending a PR
-- Run `make manifests docs` if you made any changes to any of the CRD defintions (related files: `api/*/*_types.go`)
+## Full cluster deployment
+
+For end-to-end testing with the controller running inside the cluster:
+
+```console
+$ make kind-cluster-reset
+$ export IMG=mercari/spanner-autoscaler:local
+$ make docker-build kind-load-docker-image
+$ make install deploy
+$ kubectl apply -k config/samples
+```
+
+---
+
+## Testing
+
+### Unit and webhook tests
+
+```console
+$ make test
+```
+
+This runs all tests in `./...`, including:
+
+- **Controller unit tests** (`internal/controller/`) — reconciler logic using `envtest` (a real API server).
+- **Webhook validation tests** (`api/v1beta1/`) — integration tests that exercise the admission webhook via `envtest`'s `WebhookInstallOptions`. These verify that invalid `SpannerAutoscaler` and `SpannerAutoscaleSchedule` resources are rejected, and that immutable fields cannot be changed after creation.
+
+`make test` automatically downloads the required `envtest` binaries if they are not present.
+
+### Integration tests
+
+Integration tests run against the live Spanner and Cloud Monitoring emulators. `make test-integration` starts the emulators automatically if they are not already running:
+
+```console
+$ make test-integration
+```
+
+To manage the emulators manually before running:
+
+```console
+$ make emulator-up
+$ go test -tags integration ./test/integration/... -v -count=1
+$ make emulator-down
+```
+
+---
+
+## Modifying CRD fields
+
+When you add or change fields in a CRD type file (`api/*/*_types.go`):
+
+1. **Update the type** in `api/v1beta1/*_types.go` (or `api/v1alpha1/`).
+2. **Add or update webhook validation** in `api/v1beta1/*_webhook.go`.
+3. **Add webhook tests** in `api/v1beta1/*_webhook_test.go` to cover the new validation rules.
+4. **Regenerate manifests and deepcopy code**:
+   ```console
+   $ make manifests generate
+   ```
+5. **Run all tests** to verify nothing is broken:
+   ```console
+   $ make test
+   ```
+
+---
+
+## Before sending a PR
+
+- Run `make manifests generate` if you made any changes to CRD definitions (`api/*/*_types.go`).
+- Run `make docs` if you changed anything that affects the CRD reference documentation.
+- Run `make test` and ensure all tests pass.
+- Run `make lint` and fix any reported issues.

--- a/internal/controller/spannerautoscaler_controller.go
+++ b/internal/controller/spannerautoscaler_controller.go
@@ -68,6 +68,18 @@ type SpannerAutoscalerReconciler struct {
 	scaleDownInterval time.Duration
 	scaleUpInterval   time.Duration
 
+	// spannerEndpoint and metricsEndpoint allow overriding the API endpoints
+	// for testing with emulators. When both are set, authentication is skipped.
+	spannerEndpoint string
+	metricsEndpoint string
+
+	// spannerClientFactory overrides how Spanner clients are constructed.
+	// Defaults to spanner.NewClient. Useful in tests to inject a fake client.
+	spannerClientFactory SpannerClientFactory
+
+	// syncInterval overrides the default syncer polling interval (used in tests).
+	syncInterval time.Duration
+
 	clock utilclock.Clock
 	log   logr.Logger
 	mu    sync.RWMutex
@@ -160,6 +172,62 @@ type withScaleUpInterval struct {
 
 func (o withScaleUpInterval) applySpannerAutoscalerReconciler(r *SpannerAutoscalerReconciler) {
 	r.scaleUpInterval = o.scaleUpInterval
+}
+
+// WithSpannerEndpoint overrides the Spanner API endpoint (for emulator testing).
+func WithSpannerEndpoint(endpoint string) Option {
+	return withSpannerEndpoint{endpoint: endpoint}
+}
+
+type withSpannerEndpoint struct {
+	endpoint string
+}
+
+func (o withSpannerEndpoint) applySpannerAutoscalerReconciler(r *SpannerAutoscalerReconciler) {
+	r.spannerEndpoint = o.endpoint
+}
+
+// SpannerClientFactory is a constructor function for spanner.Client.
+// The default is spanner.NewClient; tests may substitute a fake.
+type SpannerClientFactory func(ctx context.Context, projectID, instanceID string, opts ...spanner.Option) (spanner.Client, error)
+
+// WithSpannerClientFactory overrides the factory used to create Spanner clients.
+func WithSpannerClientFactory(f SpannerClientFactory) Option {
+	return withSpannerClientFactory{factory: f}
+}
+
+type withSpannerClientFactory struct {
+	factory SpannerClientFactory
+}
+
+func (o withSpannerClientFactory) applySpannerAutoscalerReconciler(r *SpannerAutoscalerReconciler) {
+	r.spannerClientFactory = o.factory
+}
+
+// WithMetricsEndpoint overrides the Cloud Monitoring API endpoint (for emulator testing).
+func WithMetricsEndpoint(endpoint string) Option {
+	return withMetricsEndpoint{endpoint: endpoint}
+}
+
+type withMetricsEndpoint struct {
+	endpoint string
+}
+
+func (o withMetricsEndpoint) applySpannerAutoscalerReconciler(r *SpannerAutoscalerReconciler) {
+	r.metricsEndpoint = o.endpoint
+}
+
+// WithSyncInterval overrides the syncer polling interval (for testing).
+func WithSyncInterval(interval time.Duration) Option {
+	return withSyncInterval{interval: interval}
+}
+
+type withSyncInterval struct {
+	interval time.Duration
+}
+
+func (o withSyncInterval) applySpannerAutoscalerReconciler(r *SpannerAutoscalerReconciler) {
+	r.syncInterval = o.interval
 }
 
 // NewSpannerAutoscalerReconciler returns a new SpannerAutoscalerReconciler.
@@ -364,6 +432,16 @@ func (r *SpannerAutoscalerReconciler) Reconcile(ctx context.Context, req ctrlrec
 	return ctrlreconcile.Result{}, nil
 }
 
+// StopAll stops all active syncers. Useful in tests to ensure syncer goroutines
+// are cleaned up when the manager shuts down.
+func (r *SpannerAutoscalerReconciler) StopAll() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, s := range r.syncers {
+		s.Stop()
+	}
+}
+
 // SetupWithManager sets up the controller with ctrlmanager.Manager.
 func (r *SpannerAutoscalerReconciler) SetupWithManager(mgr ctrlmanager.Manager) error {
 	opts := ctrlcontroller.Options{
@@ -451,34 +529,46 @@ func parseNamespacedName(name string, defaultNamespace string) types.NamespacedN
 }
 
 func (r *SpannerAutoscalerReconciler) startSyncer(ctx context.Context, log logr.Logger, nn types.NamespacedName, projectID, instanceID string, credentials *syncerpkg.Credentials) error {
-	ts, err := credentials.TokenSource(ctx)
+	useEmulators := r.spannerEndpoint != "" && r.metricsEndpoint != ""
+
+	var spannerOpts []spanner.Option
+	var metricsOpts []metrics.Option
+
+	if useEmulators {
+		spannerOpts = append(spannerOpts, spanner.WithEndpoint(r.spannerEndpoint))
+		metricsOpts = append(metricsOpts, metrics.WithEndpoint(r.metricsEndpoint))
+	} else {
+		ts, err := credentials.TokenSource(ctx)
+		if err != nil {
+			return err
+		}
+		spannerOpts = append(spannerOpts, spanner.WithTokenSource(ts))
+		metricsOpts = append(metricsOpts, metrics.WithTokenSource(ts))
+	}
+
+	spannerOpts = append(spannerOpts, spanner.WithLog(log))
+	metricsOpts = append(metricsOpts, metrics.WithLog(log))
+
+	spannerFactory := SpannerClientFactory(spanner.NewClient)
+	if r.spannerClientFactory != nil {
+		spannerFactory = r.spannerClientFactory
+	}
+	spannerClient, err := spannerFactory(ctx, projectID, instanceID, spannerOpts...)
 	if err != nil {
 		return err
 	}
 
-	spannerClient, err := spanner.NewClient(
-		ctx,
-		projectID,
-		instanceID,
-		spanner.WithTokenSource(ts),
-		spanner.WithLog(log),
-	)
+	metricsClient, err := metrics.NewClient(ctx, projectID, instanceID, metricsOpts...)
 	if err != nil {
 		return err
 	}
 
-	metricsClient, err := metrics.NewClient(
-		ctx,
-		projectID,
-		instanceID,
-		metrics.WithTokenSource(ts),
-		metrics.WithLog(log),
-	)
-	if err != nil {
-		return err
+	syncerOpts := []syncerpkg.Option{syncerpkg.WithLog(log)}
+	if r.syncInterval > 0 {
+		syncerOpts = append(syncerOpts, syncerpkg.WithInterval(r.syncInterval))
 	}
 
-	s, err := syncerpkg.New(ctx, r.ctrlClient, nn, credentials, r.recorder, spannerClient, metricsClient, syncerpkg.WithLog(log))
+	s, err := syncerpkg.New(ctx, r.ctrlClient, nn, credentials, r.recorder, spannerClient, metricsClient, syncerOpts...)
 	if err != nil {
 		return err
 	}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -96,7 +96,8 @@ var _ = BeforeSuite(func() {
 	Expect(k8sClient).NotTo(BeNil())
 
 	k8sManager, err = ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: scheme.Scheme,
+		Scheme:             scheme.Scheme,
+		MetricsBindAddress: "0",
 	})
 	Expect(err).NotTo(HaveOccurred())
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -14,6 +14,8 @@ import (
 	"golang.org/x/oauth2"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	utilclock "k8s.io/utils/clock"
 )
 
@@ -42,6 +44,7 @@ type client struct {
 	instanceID string
 	term       time.Duration
 
+	endpoint    string
 	tokenSource oauth2.TokenSource
 
 	clock utilclock.Clock
@@ -51,6 +54,12 @@ type client struct {
 var _ Client = (*client)(nil)
 
 type Option func(*client)
+
+func WithEndpoint(endpoint string) Option {
+	return func(c *client) {
+		c.endpoint = endpoint
+	}
+}
 
 func WithTerm(term time.Duration) Option {
 	return func(c *client) {
@@ -92,7 +101,13 @@ func NewClient(ctx context.Context, projectID, instanceID string, opts ...Option
 
 	var options []option.ClientOption
 
-	if c.tokenSource != nil {
+	if c.endpoint != "" {
+		options = append(options,
+			option.WithEndpoint(c.endpoint),
+			option.WithoutAuthentication(),
+			option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+		)
+	} else if c.tokenSource != nil {
 		options = append(options, option.WithTokenSource(c.tokenSource))
 	}
 
@@ -134,34 +149,27 @@ func (c *client) GetInstanceMetrics(ctx context.Context) (*InstanceMetrics, erro
 
 	it := c.monitoringMetricClient.ListTimeSeries(ctx, req)
 
-	for {
-		resp, err := it.Next()
-		if err == iterator.Done {
-			break
-		}
-
-		if err != nil {
-			log.Error(err, "unable to get metrics list time series response with iterator")
-			return nil, err
-		}
-
-		log.V(1).Info("got time series data points", "points", resp.GetPoints())
-
-		// monitoringpb.Point.GetValue().GetDoubleValue() for CPU is in [0, 1].
-		cpuPercent, err := firstPointAsPercent(resp.GetPoints())
-		if err != nil {
-			return nil, err
-		}
-
-		// TODO: Fix this loop so that lint check will pass
-		return &InstanceMetrics{ //nolint:staticcheck
-			CurrentHighPriorityCPUUtilization: cpuPercent,
-		}, nil
+	resp, err := it.Next()
+	if err == iterator.Done {
+		log.V(1).Info("could not get any time series metrics")
+		return nil, errors.New("no such spanner instance metrics")
+	}
+	if err != nil {
+		log.Error(err, "unable to get metrics list time series response with iterator")
+		return nil, err
 	}
 
-	log.V(1).Info("could not get any time series metrics")
+	log.V(1).Info("got time series data points", "points", resp.GetPoints())
 
-	return nil, errors.New("no such spanner instance metrics")
+	// monitoringpb.Point.GetValue().GetDoubleValue() for CPU is in [0, 1].
+	cpuPercent, err := firstPointAsPercent(resp.GetPoints())
+	if err != nil {
+		return nil, err
+	}
+
+	return &InstanceMetrics{
+		CurrentHighPriorityCPUUtilization: cpuPercent,
+	}, nil
 }
 
 func firstPointAsPercent(points []*monitoringpb.Point) (percent int, err error) {

--- a/internal/monitoringemulator/admin.go
+++ b/internal/monitoringemulator/admin.go
@@ -1,0 +1,214 @@
+package monitoringemulator
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// NewAdminHandler returns an HTTP handler for the monitoring emulator admin API.
+//
+// Static mode endpoints (fixed CPU utilization):
+//
+//	PUT    /metrics/{project_id}/{instance_id}   {"cpu_utilization": 0.45}
+//	GET    /metrics/{project_id}/{instance_id}
+//	DELETE /metrics/{project_id}/{instance_id}
+//
+// Dynamic mode endpoints (workload-based CPU calculation):
+//
+//	PUT    /workload/{project_id}/{instance_id}  {"cpu_utilization": 0.80, "reference_processing_units": 1000}
+//	GET    /workload/{project_id}/{instance_id}
+//	DELETE /workload/{project_id}/{instance_id}
+//
+// Scenario mode endpoints (time-based step sequence, loops indefinitely):
+//
+//	PUT    /scenario/{project_id}/{instance_id}  {"steps": [{"duration": "30s", "cpu_utilization": 0.80}, ...]}
+//	DELETE /scenario/{project_id}/{instance_id}
+func NewAdminHandler(staticStore *StaticStore, workloadStore *WorkloadStore, scenarioStore *ScenarioStore) http.Handler {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("PUT /metrics/{project_id}/{instance_id}", handleStaticSet(staticStore))
+	mux.HandleFunc("GET /metrics/{project_id}/{instance_id}", handleStaticGet(staticStore))
+	mux.HandleFunc("DELETE /metrics/{project_id}/{instance_id}", handleStaticDelete(staticStore))
+
+	mux.HandleFunc("PUT /workload/{project_id}/{instance_id}", handleWorkloadSet(workloadStore))
+	mux.HandleFunc("GET /workload/{project_id}/{instance_id}", handleWorkloadGet(workloadStore))
+	mux.HandleFunc("DELETE /workload/{project_id}/{instance_id}", handleWorkloadDelete(workloadStore))
+
+	mux.HandleFunc("PUT /scenario/{project_id}/{instance_id}", handleScenarioSet(scenarioStore))
+	mux.HandleFunc("DELETE /scenario/{project_id}/{instance_id}", handleScenarioDelete(scenarioStore))
+
+	return mux
+}
+
+// ---- static mode ----
+
+type staticSetRequest struct {
+	CPUUtilization float64 `json:"cpu_utilization"`
+}
+
+type staticResponse struct {
+	ProjectID      string  `json:"project_id"`
+	InstanceID     string  `json:"instance_id"`
+	CPUUtilization float64 `json:"cpu_utilization"`
+}
+
+func handleStaticSet(store *StaticStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		projectID := r.PathValue("project_id")
+		instanceID := r.PathValue("instance_id")
+
+		var req staticSetRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if req.CPUUtilization < 0 || req.CPUUtilization > 1 {
+			http.Error(w, "cpu_utilization must be between 0.0 and 1.0", http.StatusBadRequest)
+			return
+		}
+
+		store.Set(projectID, instanceID, req.CPUUtilization)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(staticResponse{ //nolint:errcheck
+			ProjectID:      projectID,
+			InstanceID:     instanceID,
+			CPUUtilization: req.CPUUtilization,
+		})
+	}
+}
+
+func handleStaticGet(store *StaticStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		projectID := r.PathValue("project_id")
+		instanceID := r.PathValue("instance_id")
+
+		cpu, ok := store.Get(projectID, instanceID)
+		if !ok {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(staticResponse{ //nolint:errcheck
+			ProjectID:      projectID,
+			InstanceID:     instanceID,
+			CPUUtilization: cpu,
+		})
+	}
+}
+
+func handleStaticDelete(store *StaticStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		store.Delete(r.PathValue("project_id"), r.PathValue("instance_id"))
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// ---- dynamic (workload) mode ----
+
+type workloadSetRequest struct {
+	CPUUtilization           float64 `json:"cpu_utilization"`
+	ReferenceProcessingUnits int     `json:"reference_processing_units"`
+}
+
+type workloadResponse struct {
+	ProjectID                string  `json:"project_id"`
+	InstanceID               string  `json:"instance_id"`
+	Workload                 float64 `json:"workload"`
+	ReferenceCPUUtilization  float64 `json:"reference_cpu_utilization"`
+	ReferenceProcessingUnits int     `json:"reference_processing_units"`
+}
+
+func handleWorkloadSet(store *WorkloadStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		projectID := r.PathValue("project_id")
+		instanceID := r.PathValue("instance_id")
+
+		var req workloadSetRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if req.CPUUtilization < 0 || req.CPUUtilization > 1 {
+			http.Error(w, "cpu_utilization must be between 0.0 and 1.0", http.StatusBadRequest)
+			return
+		}
+		if req.ReferenceProcessingUnits <= 0 {
+			http.Error(w, "reference_processing_units must be greater than 0", http.StatusBadRequest)
+			return
+		}
+
+		store.Set(projectID, instanceID, req.CPUUtilization, req.ReferenceProcessingUnits)
+		entry, _ := store.Get(projectID, instanceID)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(workloadResponse{ //nolint:errcheck
+			ProjectID:                projectID,
+			InstanceID:               instanceID,
+			Workload:                 entry.Workload,
+			ReferenceCPUUtilization:  entry.ReferenceCPU,
+			ReferenceProcessingUnits: entry.ReferencePU,
+		})
+	}
+}
+
+func handleWorkloadGet(store *WorkloadStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		projectID := r.PathValue("project_id")
+		instanceID := r.PathValue("instance_id")
+
+		entry, ok := store.Get(projectID, instanceID)
+		if !ok {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(workloadResponse{ //nolint:errcheck
+			ProjectID:                projectID,
+			InstanceID:               instanceID,
+			Workload:                 entry.Workload,
+			ReferenceCPUUtilization:  entry.ReferenceCPU,
+			ReferenceProcessingUnits: entry.ReferencePU,
+		})
+	}
+}
+
+func handleWorkloadDelete(store *WorkloadStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		store.Delete(r.PathValue("project_id"), r.PathValue("instance_id"))
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// ---- scenario mode ----
+
+type scenarioSetRequest struct {
+	Steps []ScenarioStep `json:"steps"`
+}
+
+func handleScenarioSet(store *ScenarioStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		projectID := r.PathValue("project_id")
+		instanceID := r.PathValue("instance_id")
+
+		var req scenarioSetRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if err := store.Set(projectID, instanceID, req.Steps); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+func handleScenarioDelete(store *ScenarioStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		store.Delete(r.PathValue("project_id"), r.PathValue("instance_id"))
+		w.WriteHeader(http.StatusNoContent)
+	}
+}

--- a/internal/monitoringemulator/admin.go
+++ b/internal/monitoringemulator/admin.go
@@ -70,7 +70,7 @@ func handleStaticSet(store *StaticStore) http.HandlerFunc {
 		store.Set(projectID, instanceID, req.CPUUtilization)
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(staticResponse{ //nolint:errcheck
+		json.NewEncoder(w).Encode(staticResponse{ //nolint:errcheck,gosec
 			ProjectID:      projectID,
 			InstanceID:     instanceID,
 			CPUUtilization: req.CPUUtilization,
@@ -90,7 +90,7 @@ func handleStaticGet(store *StaticStore) http.HandlerFunc {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(staticResponse{ //nolint:errcheck
+		json.NewEncoder(w).Encode(staticResponse{ //nolint:errcheck,gosec
 			ProjectID:      projectID,
 			InstanceID:     instanceID,
 			CPUUtilization: cpu,
@@ -143,7 +143,7 @@ func handleWorkloadSet(store *WorkloadStore) http.HandlerFunc {
 		entry, _ := store.Get(projectID, instanceID)
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(workloadResponse{ //nolint:errcheck
+		json.NewEncoder(w).Encode(workloadResponse{ //nolint:errcheck,gosec
 			ProjectID:                projectID,
 			InstanceID:               instanceID,
 			Workload:                 entry.Workload,
@@ -165,7 +165,7 @@ func handleWorkloadGet(store *WorkloadStore) http.HandlerFunc {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(workloadResponse{ //nolint:errcheck
+		json.NewEncoder(w).Encode(workloadResponse{ //nolint:errcheck,gosec
 			ProjectID:                projectID,
 			InstanceID:               instanceID,
 			Workload:                 entry.Workload,

--- a/internal/monitoringemulator/filter.go
+++ b/internal/monitoringemulator/filter.go
@@ -1,0 +1,34 @@
+package monitoringemulator
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var instanceIDRegex = regexp.MustCompile(`resource\.label\.instance_id\s*=\s*"([^"]+)"`)
+
+// extractInstanceID extracts the instance_id value from a Cloud Monitoring filter string.
+//
+// Example filter:
+//
+//	metric.type = "spanner.googleapis.com/instance/cpu/utilization_by_priority" AND
+//	metric.label.priority = "high" AND
+//	resource.label.instance_id = "my-instance"
+func extractInstanceID(filter string) (string, error) {
+	matches := instanceIDRegex.FindStringSubmatch(filter)
+	if len(matches) < 2 {
+		return "", fmt.Errorf("instance_id not found in filter: %s", filter)
+	}
+	return matches[1], nil
+}
+
+// extractProjectID extracts the project ID from a Cloud Monitoring resource name.
+// The name must be in the format "projects/{project_id}".
+func extractProjectID(name string) (string, error) {
+	parts := strings.SplitN(name, "/", 2)
+	if len(parts) != 2 || parts[0] != "projects" || parts[1] == "" {
+		return "", fmt.Errorf("invalid resource name (expected \"projects/{project_id}\"): %q", name)
+	}
+	return parts[1], nil
+}

--- a/internal/monitoringemulator/filter_test.go
+++ b/internal/monitoringemulator/filter_test.go
@@ -1,0 +1,94 @@
+package monitoringemulator
+
+import "testing"
+
+func TestExtractInstanceID(t *testing.T) {
+	tests := []struct {
+		name    string
+		filter  string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "full spanner-autoscaler filter",
+			filter: `metric.type = "spanner.googleapis.com/instance/cpu/utilization_by_priority" AND
+		metric.label.priority = "high" AND
+		resource.label.instance_id = "my-instance"`,
+			want: "my-instance",
+		},
+		{
+			name:   "spaces around equals sign",
+			filter: `resource.label.instance_id  =  "spaced-instance"`,
+			want:   "spaced-instance",
+		},
+		{
+			name:    "missing instance_id",
+			filter:  `metric.type = "some.metric"`,
+			wantErr: true,
+		},
+		{
+			name:    "empty filter",
+			filter:  "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractInstanceID(tt.filter)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("extractInstanceID() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("extractInstanceID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractProjectID(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "valid name",
+			input: "projects/my-project",
+			want:  "my-project",
+		},
+		{
+			name:    "wrong prefix",
+			input:   "folders/my-project",
+			wantErr: true,
+		},
+		{
+			name:    "empty project ID",
+			input:   "projects/",
+			wantErr: true,
+		},
+		{
+			name:    "no slash",
+			input:   "my-project",
+			wantErr: true,
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractProjectID(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("extractProjectID() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("extractProjectID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/monitoringemulator/scenario_store.go
+++ b/internal/monitoringemulator/scenario_store.go
@@ -14,7 +14,7 @@ import (
 //
 //   - CPUUtilization: returns a fixed CPU value regardless of current PU.
 //   - Workload: computes CPU dynamically (cpu = workload / current_pu),
-//     modelling real Cloud Spanner behaviour where scaling up reduces CPU.
+//     modeling real Cloud Spanner behavior where scaling up reduces CPU.
 type ScenarioStep struct {
 	Duration       Duration          `json:"duration"`
 	CPUUtilization *float64          `json:"cpu_utilization,omitempty"`
@@ -137,7 +137,7 @@ func (s *ScenarioStore) Delete(project, instanceID string) {
 
 // LoadFile loads a scenario YAML file and populates the store.
 func (s *ScenarioStore) LoadFile(path string) error {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) //nolint:gosec
 	if err != nil {
 		return fmt.Errorf("read scenario file: %w", err)
 	}

--- a/internal/monitoringemulator/scenario_store.go
+++ b/internal/monitoringemulator/scenario_store.go
@@ -1,0 +1,154 @@
+package monitoringemulator
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	sigsyaml "sigs.k8s.io/yaml"
+)
+
+// ScenarioStep is one step in a scenario sequence.
+// Exactly one of CPUUtilization or Workload must be set.
+//
+//   - CPUUtilization: returns a fixed CPU value regardless of current PU.
+//   - Workload: computes CPU dynamically (cpu = workload / current_pu),
+//     modelling real Cloud Spanner behaviour where scaling up reduces CPU.
+type ScenarioStep struct {
+	Duration       Duration          `json:"duration"`
+	CPUUtilization *float64          `json:"cpu_utilization,omitempty"`
+	Workload       *WorkloadScenario `json:"workload,omitempty"`
+}
+
+// WorkloadScenario holds the parameters for a workload-based step.
+type WorkloadScenario struct {
+	CPUUtilization           float64 `json:"cpu_utilization"`
+	ReferenceProcessingUnits int     `json:"reference_processing_units"`
+}
+
+// scenarioFile is the top-level structure of a scenario YAML file.
+type scenarioFile struct {
+	Instances []instanceScenario `json:"instances"`
+}
+
+type instanceScenario struct {
+	Project  string         `json:"project"`
+	Instance string         `json:"instance"`
+	Steps    []ScenarioStep `json:"steps"`
+}
+
+// Duration wraps time.Duration for YAML/JSON unmarshalling from strings like "30s".
+type Duration struct{ time.Duration }
+
+func (d *Duration) UnmarshalJSON(b []byte) error {
+	s := string(b)
+	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
+		s = s[1 : len(s)-1]
+	}
+	v, err := time.ParseDuration(s)
+	if err != nil {
+		return fmt.Errorf("invalid duration %q: %w", s, err)
+	}
+	d.Duration = v
+	return nil
+}
+
+// scenarioEntry tracks the runtime state of one instance's scenario.
+type scenarioEntry struct {
+	steps     []ScenarioStep
+	total     time.Duration // sum of all step durations
+	startTime time.Time
+}
+
+// currentStep returns the step active at the current moment.
+// The scenario loops indefinitely.
+func (e *scenarioEntry) currentStep() ScenarioStep {
+	elapsed := time.Since(e.startTime) % e.total
+	var cum time.Duration
+	for _, step := range e.steps {
+		cum += step.Duration.Duration
+		if elapsed < cum {
+			return step
+		}
+	}
+	return e.steps[len(e.steps)-1]
+}
+
+// ScenarioStore holds time-based CPU scenarios per Spanner instance.
+// It is safe for concurrent use.
+type ScenarioStore struct {
+	mu   sync.RWMutex
+	data map[string]*scenarioEntry
+}
+
+func NewScenarioStore() *ScenarioStore {
+	return &ScenarioStore{data: make(map[string]*scenarioEntry)}
+}
+
+// Set registers a scenario for the given instance, starting from now.
+func (s *ScenarioStore) Set(project, instanceID string, steps []ScenarioStep) error {
+	if len(steps) == 0 {
+		return fmt.Errorf("scenario must have at least one step")
+	}
+	var total time.Duration
+	for i, step := range steps {
+		if step.Duration.Duration <= 0 {
+			return fmt.Errorf("step %d: duration must be positive", i)
+		}
+		if step.CPUUtilization == nil && step.Workload == nil {
+			return fmt.Errorf("step %d: must set cpu_utilization or workload", i)
+		}
+		if step.CPUUtilization != nil && step.Workload != nil {
+			return fmt.Errorf("step %d: cpu_utilization and workload are mutually exclusive", i)
+		}
+		if step.CPUUtilization != nil && (*step.CPUUtilization < 0 || *step.CPUUtilization > 1) {
+			return fmt.Errorf("step %d: cpu_utilization must be between 0.0 and 1.0", i)
+		}
+		total += step.Duration.Duration
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[storeKey(project, instanceID)] = &scenarioEntry{
+		steps:     steps,
+		total:     total,
+		startTime: time.Now(),
+	}
+	return nil
+}
+
+// Get returns the current active step for the instance, if a scenario is registered.
+func (s *ScenarioStore) Get(project, instanceID string) (ScenarioStep, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	e, ok := s.data[storeKey(project, instanceID)]
+	if !ok {
+		return ScenarioStep{}, false
+	}
+	return e.currentStep(), true
+}
+
+// Delete removes the scenario for the given instance.
+func (s *ScenarioStore) Delete(project, instanceID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.data, storeKey(project, instanceID))
+}
+
+// LoadFile loads a scenario YAML file and populates the store.
+func (s *ScenarioStore) LoadFile(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read scenario file: %w", err)
+	}
+	var f scenarioFile
+	if err := sigsyaml.Unmarshal(data, &f); err != nil {
+		return fmt.Errorf("parse scenario file: %w", err)
+	}
+	for _, inst := range f.Instances {
+		if err := s.Set(inst.Project, inst.Instance, inst.Steps); err != nil {
+			return fmt.Errorf("instance %s/%s: %w", inst.Project, inst.Instance, err)
+		}
+	}
+	return nil
+}

--- a/internal/monitoringemulator/server.go
+++ b/internal/monitoringemulator/server.go
@@ -1,0 +1,145 @@
+package monitoringemulator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	monitoringpb "cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
+	spanneradmin "cloud.google.com/go/spanner/admin/instance/apiv1"
+	instancepb "cloud.google.com/go/spanner/admin/instance/apiv1/instancepb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// MetricServiceServer implements the Cloud Monitoring MetricService gRPC interface.
+// Only ListTimeSeries is implemented; all other methods return Unimplemented via
+// the embedded UnimplementedMetricServiceServer.
+//
+// Three modes are supported, checked in priority order:
+//
+//  1. Scenario mode: steps through a time-based sequence of CPU values
+//     loaded from a YAML file or set via the admin API
+//     (PUT /scenario/{project}/{instance}).
+//
+//  2. Dynamic mode: calculates CPU utilization from a constant workload and the
+//     current Spanner instance processing units, queried live from the Spanner
+//     Emulator (PUT /workload/{project}/{instance}).
+//
+//  3. Static mode: returns a fixed CPU utilization value set via the admin API
+//     (PUT /metrics/{project}/{instance}).
+//
+// If none is configured for the requested instance, an empty TimeSeries
+// list is returned, which causes metrics.Client.GetInstanceMetrics to return
+// "no such spanner instance metrics".
+type MetricServiceServer struct {
+	monitoringpb.UnimplementedMetricServiceServer
+	staticStore        *StaticStore
+	workloadStore      *WorkloadStore
+	scenarioStore      *ScenarioStore
+	spannerAdminClient *spanneradmin.InstanceAdminClient // nil → dynamic mode unavailable
+}
+
+func NewMetricServiceServer(
+	staticStore *StaticStore,
+	workloadStore *WorkloadStore,
+	scenarioStore *ScenarioStore,
+	spannerAdminClient *spanneradmin.InstanceAdminClient,
+) *MetricServiceServer {
+	return &MetricServiceServer{
+		staticStore:        staticStore,
+		workloadStore:      workloadStore,
+		scenarioStore:      scenarioStore,
+		spannerAdminClient: spannerAdminClient,
+	}
+}
+
+func (s *MetricServiceServer) ListTimeSeries(
+	ctx context.Context,
+	req *monitoringpb.ListTimeSeriesRequest,
+) (*monitoringpb.ListTimeSeriesResponse, error) {
+	projectID, err := extractProjectID(req.GetName())
+	if err != nil {
+		return nil, err
+	}
+	instanceID, err := extractInstanceID(req.GetFilter())
+	if err != nil {
+		return nil, err
+	}
+
+	// Priority 1: ScenarioStore (time-based scenario mode)
+	if step, ok := s.scenarioStore.Get(projectID, instanceID); ok {
+		if step.Workload != nil {
+			cpu, err := s.calcCPUFromWorkload(ctx, projectID, instanceID,
+				step.Workload.CPUUtilization*float64(step.Workload.ReferenceProcessingUnits))
+			if err != nil {
+				return nil, err
+			}
+			return buildResponse(cpu), nil
+		}
+		return buildResponse(*step.CPUUtilization), nil
+	}
+
+	// Priority 2: WorkloadStore (dynamic mode)
+	if entry, ok := s.workloadStore.Get(projectID, instanceID); ok {
+		cpu, err := s.calcCPUFromWorkload(ctx, projectID, instanceID, entry.Workload)
+		if err != nil {
+			return nil, err
+		}
+		return buildResponse(cpu), nil
+	}
+
+	// Priority 3: StaticStore (static mode)
+	if cpu, ok := s.staticStore.Get(projectID, instanceID); ok {
+		return buildResponse(cpu), nil
+	}
+
+	// None configured: empty response causes "no such spanner instance metrics" in the caller.
+	return &monitoringpb.ListTimeSeriesResponse{}, nil
+}
+
+// calcCPUFromWorkload queries the Spanner Emulator for the current processing
+// units of the instance and computes:
+//
+//	cpu = workload / current_processing_units
+func (s *MetricServiceServer) calcCPUFromWorkload(
+	ctx context.Context, projectID, instanceID string, workload float64,
+) (float64, error) {
+	if s.spannerAdminClient == nil {
+		return 0, errors.New("dynamic mode requires SPANNER_EMULATOR_HOST to be set")
+	}
+	resp, err := s.spannerAdminClient.GetInstance(ctx, &instancepb.GetInstanceRequest{
+		Name: fmt.Sprintf("projects/%s/instances/%s", projectID, instanceID),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to get instance from spanner emulator: %w", err)
+	}
+	currentPU := float64(resp.GetProcessingUnits())
+	if currentPU == 0 {
+		return 0, errors.New("instance has 0 processing units")
+	}
+	return workload / currentPU, nil
+}
+
+func buildResponse(cpuUtilization float64) *monitoringpb.ListTimeSeriesResponse {
+	now := time.Now()
+	return &monitoringpb.ListTimeSeriesResponse{
+		TimeSeries: []*monitoringpb.TimeSeries{
+			{
+				Points: []*monitoringpb.Point{
+					{
+						Interval: &monitoringpb.TimeInterval{
+							StartTime: timestamppb.New(now.Add(-time.Minute)),
+							EndTime:   timestamppb.New(now),
+						},
+						Value: &monitoringpb.TypedValue{
+							Value: &monitoringpb.TypedValue_DoubleValue{
+								DoubleValue: cpuUtilization,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/monitoringemulator/static_store.go
+++ b/internal/monitoringemulator/static_store.go
@@ -1,0 +1,40 @@
+package monitoringemulator
+
+import "sync"
+
+// storeKey returns a unique key for the given project and instance ID.
+func storeKey(project, instanceID string) string {
+	return project + "/" + instanceID
+}
+
+// StaticStore holds fixed CPU utilization values per Spanner instance.
+// It is safe for concurrent use.
+type StaticStore struct {
+	mu   sync.RWMutex
+	data map[string]float64
+}
+
+func NewStaticStore() *StaticStore {
+	return &StaticStore{
+		data: make(map[string]float64),
+	}
+}
+
+func (s *StaticStore) Set(project, instanceID string, cpuUtilization float64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[storeKey(project, instanceID)] = cpuUtilization
+}
+
+func (s *StaticStore) Get(project, instanceID string) (float64, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	v, ok := s.data[storeKey(project, instanceID)]
+	return v, ok
+}
+
+func (s *StaticStore) Delete(project, instanceID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.data, storeKey(project, instanceID))
+}

--- a/internal/monitoringemulator/workload_store.go
+++ b/internal/monitoringemulator/workload_store.go
@@ -9,7 +9,7 @@ import "sync"
 //	workload = cpu_utilization × processing_units  (constant)
 //	current_cpu = workload / current_processing_units
 //
-// This models the behaviour of real Cloud Spanner: scaling up PUs reduces CPU
+// This models the behavior of real Cloud Spanner: scaling up PUs reduces CPU
 // utilization proportionally for the same workload.
 type WorkloadEntry struct {
 	Workload     float64 // ReferenceCPU * ReferencePU

--- a/internal/monitoringemulator/workload_store.go
+++ b/internal/monitoringemulator/workload_store.go
@@ -1,0 +1,56 @@
+package monitoringemulator
+
+import "sync"
+
+// WorkloadEntry holds the constant workload value for a Spanner instance.
+//
+// The relationship between CPU utilization, processing units, and workload is:
+//
+//	workload = cpu_utilization × processing_units  (constant)
+//	current_cpu = workload / current_processing_units
+//
+// This models the behaviour of real Cloud Spanner: scaling up PUs reduces CPU
+// utilization proportionally for the same workload.
+type WorkloadEntry struct {
+	Workload     float64 // ReferenceCPU * ReferencePU
+	ReferenceCPU float64
+	ReferencePU  int
+}
+
+// WorkloadStore holds workload-based dynamic CPU calculation parameters per
+// Spanner instance. It is safe for concurrent use.
+type WorkloadStore struct {
+	mu   sync.RWMutex
+	data map[string]WorkloadEntry
+}
+
+func NewWorkloadStore() *WorkloadStore {
+	return &WorkloadStore{
+		data: make(map[string]WorkloadEntry),
+	}
+}
+
+// Set stores a workload entry derived from the reference CPU utilization and
+// reference processing units.
+func (s *WorkloadStore) Set(project, instanceID string, cpuUtilization float64, referencePU int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[storeKey(project, instanceID)] = WorkloadEntry{
+		Workload:     cpuUtilization * float64(referencePU),
+		ReferenceCPU: cpuUtilization,
+		ReferencePU:  referencePU,
+	}
+}
+
+func (s *WorkloadStore) Get(project, instanceID string) (WorkloadEntry, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	v, ok := s.data[storeKey(project, instanceID)]
+	return v, ok
+}
+
+func (s *WorkloadStore) Delete(project, instanceID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.data, storeKey(project, instanceID))
+}

--- a/internal/spanner/fake/fake.go
+++ b/internal/spanner/fake/fake.go
@@ -1,0 +1,42 @@
+package fake
+
+import (
+	"context"
+	"sync"
+
+	"github.com/mercari/spanner-autoscaler/internal/spanner"
+)
+
+// Client is an in-memory fake spanner.Client for use in integration tests.
+// The Cloud Spanner Emulator does not support UpdateInstance, so this client
+// simulates instance state locally.
+type Client struct {
+	mu              sync.Mutex
+	processingUnits int
+	instanceState   spanner.State
+}
+
+var _ spanner.Client = (*Client)(nil)
+
+func NewClient(processingUnits int) *Client {
+	return &Client{
+		processingUnits: processingUnits,
+		instanceState:   spanner.StateReady,
+	}
+}
+
+func (c *Client) GetInstance(_ context.Context) (*spanner.Instance, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return &spanner.Instance{
+		ProcessingUnits: c.processingUnits,
+		InstanceState:   c.instanceState,
+	}, nil
+}
+
+func (c *Client) UpdateInstance(_ context.Context, instance *spanner.Instance) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.processingUnits = instance.ProcessingUnits
+	return nil
+}

--- a/internal/spanner/spanner.go
+++ b/internal/spanner/spanner.go
@@ -10,6 +10,8 @@ import (
 	"golang.org/x/oauth2"
 	"google.golang.org/api/option"
 	field_mask "google.golang.org/genproto/protobuf/field_mask"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	spannerv1beta1 "github.com/mercari/spanner-autoscaler/api/v1beta1"
 )
@@ -44,6 +46,7 @@ type client struct {
 	projectID  string
 	instanceID string
 
+	endpoint    string
 	tokenSource oauth2.TokenSource
 	log         logr.Logger
 }
@@ -51,6 +54,12 @@ type client struct {
 var _ Client = (*client)(nil)
 
 type Option func(*client)
+
+func WithEndpoint(endpoint string) Option {
+	return func(c *client) {
+		c.endpoint = endpoint
+	}
+}
 
 func WithTokenSource(ts oauth2.TokenSource) Option {
 	return func(c *client) {
@@ -78,7 +87,13 @@ func NewClient(ctx context.Context, projectID, instanceID string, opts ...Option
 
 	var options []option.ClientOption
 
-	if c.tokenSource != nil {
+	if c.endpoint != "" {
+		options = append(options,
+			option.WithEndpoint(c.endpoint),
+			option.WithoutAuthentication(),
+			option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+		)
+	} else if c.tokenSource != nil {
 		options = append(options, option.WithTokenSource(c.tokenSource))
 	}
 

--- a/internal/spanneremulator/admin.go
+++ b/internal/spanneremulator/admin.go
@@ -45,7 +45,7 @@ func handleUpsert(srv *Server) http.HandlerFunc {
 		srv.AdminUpsertInstance(name, req.ProcessingUnits)
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(instanceResponse{ //nolint:errcheck
+		json.NewEncoder(w).Encode(instanceResponse{ //nolint:errcheck,gosec
 			Name:            name,
 			ProcessingUnits: req.ProcessingUnits,
 		})

--- a/internal/spanneremulator/admin.go
+++ b/internal/spanneremulator/admin.go
@@ -1,0 +1,63 @@
+package spanneremulator
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// NewAdminHandler returns an HTTP handler for the Spanner emulator admin API.
+//
+//	PUT    /instances/{project_id}/{instance_id}   {"processing_units": 1000}
+//	DELETE /instances/{project_id}/{instance_id}
+func NewAdminHandler(srv *Server) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("PUT /instances/{project_id}/{instance_id}", handleUpsert(srv))
+	mux.HandleFunc("DELETE /instances/{project_id}/{instance_id}", handleDelete(srv))
+	return mux
+}
+
+type upsertRequest struct {
+	ProcessingUnits int32 `json:"processing_units"`
+}
+
+type instanceResponse struct {
+	Name            string `json:"name"`
+	ProcessingUnits int32  `json:"processing_units"`
+}
+
+func handleUpsert(srv *Server) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		projectID := r.PathValue("project_id")
+		instanceID := r.PathValue("instance_id")
+
+		var req upsertRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if req.ProcessingUnits <= 0 {
+			http.Error(w, "processing_units must be greater than 0", http.StatusBadRequest)
+			return
+		}
+
+		name := fmt.Sprintf("projects/%s/instances/%s", projectID, instanceID)
+		srv.AdminUpsertInstance(name, req.ProcessingUnits)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(instanceResponse{ //nolint:errcheck
+			Name:            name,
+			ProcessingUnits: req.ProcessingUnits,
+		})
+	}
+}
+
+func handleDelete(srv *Server) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		projectID := r.PathValue("project_id")
+		instanceID := r.PathValue("instance_id")
+		name := fmt.Sprintf("projects/%s/instances/%s", projectID, instanceID)
+		srv.AdminDeleteInstance(name)
+		w.WriteHeader(http.StatusNoContent)
+	}
+}

--- a/internal/spanneremulator/server.go
+++ b/internal/spanneremulator/server.go
@@ -1,0 +1,126 @@
+// Package spanneremulator provides a minimal in-memory implementation of the
+// Cloud Spanner Instance Admin gRPC service for use in integration tests.
+//
+// Only the operations used by spanner-autoscaler are implemented:
+//
+//   - GetInstance
+//   - UpdateInstance
+//
+// All other methods return codes.Unimplemented via the embedded
+// UnimplementedInstanceAdminServer.
+//
+// Long-running operations (UpdateInstance) are returned as already completed
+// (Done: true) so callers do not need to poll GetOperation.
+//
+// To pre-populate instances for tests, use the HTTP admin API (admin.go).
+package spanneremulator
+
+import (
+	"context"
+	"sync"
+
+	longrunningpb "cloud.google.com/go/longrunning/autogen/longrunningpb"
+	instancepb "cloud.google.com/go/spanner/admin/instance/apiv1/instancepb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+// Server implements instancepb.InstanceAdminServer with in-memory state.
+type Server struct {
+	instancepb.UnimplementedInstanceAdminServer
+
+	mu        sync.RWMutex
+	instances map[string]*instancepb.Instance // key: "projects/{p}/instances/{i}"
+}
+
+// NewServer returns a new Server with an empty instance store.
+func NewServer() *Server {
+	return &Server{
+		instances: make(map[string]*instancepb.Instance),
+	}
+}
+
+// GetInstance returns the named instance or codes.NotFound.
+func (s *Server) GetInstance(_ context.Context, req *instancepb.GetInstanceRequest) (*instancepb.Instance, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	inst, ok := s.instances[req.GetName()]
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "instance %q not found", req.GetName())
+	}
+	return inst, nil
+}
+
+// UpdateInstance applies field-masked updates to an existing instance and
+// returns a completed LRO.
+func (s *Server) UpdateInstance(_ context.Context, req *instancepb.UpdateInstanceRequest) (*longrunningpb.Operation, error) {
+	patch := req.GetInstance()
+	if patch == nil || patch.GetName() == "" {
+		return nil, status.Error(codes.InvalidArgument, "instance.name is required")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	existing, ok := s.instances[patch.GetName()]
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "instance %q not found", patch.GetName())
+	}
+
+	if mask := req.GetFieldMask(); mask != nil {
+		for _, path := range mask.GetPaths() {
+			switch path {
+			case "processing_units":
+				existing.ProcessingUnits = patch.ProcessingUnits
+			case "node_count":
+				existing.NodeCount = patch.NodeCount
+			case "display_name":
+				existing.DisplayName = patch.DisplayName
+			}
+		}
+	} else {
+		existing.ProcessingUnits = patch.ProcessingUnits
+		existing.NodeCount = patch.NodeCount
+		existing.DisplayName = patch.DisplayName
+	}
+
+	return completedOperation(existing)
+}
+
+// AdminUpsertInstance creates or replaces an instance. Used by the HTTP admin API.
+func (s *Server) AdminUpsertInstance(name string, processingUnits int32) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.instances[name] = &instancepb.Instance{
+		Name:            name,
+		DisplayName:     name,
+		ProcessingUnits: processingUnits,
+		State:           instancepb.Instance_READY,
+	}
+}
+
+// AdminDeleteInstance removes an instance. Used by the HTTP admin API.
+func (s *Server) AdminDeleteInstance(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.instances, name)
+}
+
+// completedOperation wraps inst in an already-Done LRO response.
+// The Spanner client library checks Done before polling GetOperation,
+// so no OperationsServer is needed.
+func completedOperation(inst *instancepb.Instance) (*longrunningpb.Operation, error) {
+	result, err := anypb.New(inst)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "marshal operation result: %v", err)
+	}
+	return &longrunningpb.Operation{
+		Name: inst.GetName() + "/operations/op",
+		Done: true,
+		Result: &longrunningpb.Operation_Response{
+			Response: result,
+		},
+	}, nil
+}

--- a/scenarios/default.yaml
+++ b/scenarios/default.yaml
@@ -1,0 +1,36 @@
+# Default development scenario for spanner-autoscaler.
+#
+# Demonstrates a full scale-up → stable → scale-down cycle.
+# The scenario loops indefinitely so you can watch the controller
+# respond to changing CPU utilization without any manual intervention.
+#
+# Workload mode is used so that CPU decreases realistically as the
+# controller scales up processing units:
+#   cpu = (reference_cpu * reference_pu) / current_pu
+#
+# To use a different project/instance, copy this file and update the
+# fields below, then set SCENARIO_FILE to your copy in docker-compose.yml.
+instances:
+  - project: beta-project
+    instance: beta-instance
+    steps:
+      # High load: CPU 80% at 1000 PU → controller should scale up.
+      - duration: 60s
+        workload:
+          cpu_utilization: 0.80
+          reference_processing_units: 1000
+
+      # After scale-up the workload model naturally brings CPU down.
+      # This step gives the controller time to observe the new steady state.
+      - duration: 90s
+        workload:
+          cpu_utilization: 0.80
+          reference_processing_units: 1000
+
+      # Low load: CPU drops to 15% → controller should scale down.
+      - duration: 60s
+        cpu_utilization: 0.15
+
+      # Recovery: back to moderate load before the next cycle.
+      - duration: 30s
+        cpu_utilization: 0.40

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -1,0 +1,167 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	k8sscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	spannerv1alpha1 "github.com/mercari/spanner-autoscaler/api/v1alpha1"
+	spannerv1beta1 "github.com/mercari/spanner-autoscaler/api/v1beta1"
+	"github.com/mercari/spanner-autoscaler/internal/controller"
+)
+
+// TestController_E2E_ScaleUp verifies the full scale-up flow:
+//
+//  1. A Spanner instance starts at 1000 PU in the Spanner emulator.
+//  2. A workload is configured in the Monitoring Emulator so that at 1000 PU the
+//     CPU utilization is 0.80 (80%), which exceeds the target of 40%.
+//  3. The controller syncs the status (via the syncer) and decides to scale up.
+//  4. The test waits until the Spanner emulator instance PU increases.
+func TestController_E2E_ScaleUp(t *testing.T) {
+	const (
+		projectID         = "e2e-project"
+		instanceID        = "e2e-instance"
+		initPU            = 1000
+		referenceCPU      = 0.80
+		targetCPU         = 40 // percent
+		syncInterval      = 3 * time.Second
+		scaleUpInterval   = 1 * time.Second
+		scaleDownInterval = 55 * time.Minute
+	)
+
+	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	// Configure dynamic (workload) mode in the monitoring emulator.
+	// At 1000 PU with cpu=0.80: workload = 0.80 * 1000 = 800.
+	// After scale-up to e.g. 2000 PU: cpu = 800 / 2000 = 0.40 → at target.
+	body, _ := json.Marshal(map[string]interface{}{
+		"cpu_utilization":            referenceCPU,
+		"reference_processing_units": initPU,
+	})
+	adminPUT(t, fmt.Sprintf("/workload/%s/%s", projectID, instanceID), body)
+	t.Cleanup(func() { adminDELETE(t, fmt.Sprintf("/workload/%s/%s", projectID, instanceID)) })
+
+	// Create Spanner instance in the emulator.
+	createSpannerInstance(t, projectID, instanceID, initPU)
+
+	// Start envtest with a manager (needed for controller).
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join(repoRoot(), "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+	cfg, err := testEnv.Start()
+	if err != nil {
+		t.Fatalf("failed to start envtest: %v", err)
+	}
+	t.Cleanup(func() { testEnv.Stop() }) //nolint:errcheck
+
+	if err := spannerv1alpha1.AddToScheme(k8sscheme.Scheme); err != nil {
+		t.Fatalf("add v1alpha1 scheme: %v", err)
+	}
+	if err := spannerv1beta1.AddToScheme(k8sscheme.Scheme); err != nil {
+		t.Fatalf("add v1beta1 scheme: %v", err)
+	}
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{Scheme: k8sscheme.Scheme})
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	reconciler := controller.NewSpannerAutoscalerReconciler(
+		mgr.GetClient(),
+		mgr.GetAPIReader(),
+		mgr.GetScheme(),
+		mgr.GetEventRecorderFor("e2e-controller"),
+		logf.Log.WithName("e2e"),
+		controller.WithSpannerEndpoint(spannerEmulatorAddr()),
+		controller.WithMetricsEndpoint(monitoringGRPCAddr()),
+		controller.WithSyncInterval(syncInterval),
+		controller.WithScaleUpInterval(scaleUpInterval),
+		controller.WithScaleDownInterval(scaleDownInterval),
+	)
+	if err := reconciler.SetupWithManager(mgr); err != nil {
+		t.Fatalf("failed to setup controller: %v", err)
+	}
+
+	mgrCtx, mgrCancel := context.WithCancel(context.Background())
+	t.Cleanup(mgrCancel)
+	t.Cleanup(reconciler.StopAll) // runs before mgrCancel (LIFO); stops syncer goroutines
+	go func() {
+		if err := mgr.Start(mgrCtx); err != nil {
+			t.Logf("manager exited: %v", err)
+		}
+	}()
+
+	k8sClient := mgr.GetClient()
+	ctx := context.Background()
+	nn := types.NamespacedName{Namespace: "default", Name: "e2e-sa"}
+
+	sa := &spannerv1beta1.SpannerAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nn.Name,
+			Namespace: nn.Namespace,
+		},
+		Spec: spannerv1beta1.SpannerAutoscalerSpec{
+			TargetInstance: spannerv1beta1.TargetInstance{
+				ProjectID:  projectID,
+				InstanceID: instanceID,
+			},
+			Authentication: spannerv1beta1.Authentication{
+				Type: spannerv1beta1.AuthTypeADC,
+			},
+			ScaleConfig: spannerv1beta1.ScaleConfig{
+				ComputeType: spannerv1beta1.ComputeTypePU,
+				ProcessingUnits: spannerv1beta1.ScaleConfigPUs{
+					Min: 100,
+					Max: 10000,
+				},
+				ScaledownStepSize: intstr.FromInt(2000),
+				ScaleupStepSize:   intstr.FromInt(1000),
+				TargetCPUUtilization: spannerv1beta1.TargetCPUUtilization{
+					HighPriority: targetCPU,
+				},
+			},
+		},
+	}
+	if err := k8sClient.Create(ctx, sa); err != nil {
+		t.Fatalf("failed to create SpannerAutoscaler: %v", err)
+	}
+
+	// Wait for the controller to scale up the Spanner instance.
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		var updated spannerv1beta1.SpannerAutoscaler
+		if err := k8sClient.Get(ctx, nn, &updated); err != nil {
+			time.Sleep(time.Second)
+			continue
+		}
+		if updated.Status.CurrentProcessingUnits > initPU {
+			t.Logf("scale-up succeeded: PU %d → %d (CPU=%d%%)",
+				initPU, updated.Status.CurrentProcessingUnits,
+				updated.Status.CurrentHighPriorityCPUUtilization)
+			return
+		}
+		time.Sleep(time.Second)
+	}
+
+	var updated spannerv1beta1.SpannerAutoscaler
+	k8sClient.Get(ctx, nn, &updated) //nolint:errcheck
+	t.Errorf("controller did not scale up within timeout: PU=%d (want >%d), CPU=%d%%",
+		updated.Status.CurrentProcessingUnits, initPU,
+		updated.Status.CurrentHighPriorityCPUUtilization)
+}

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -1,0 +1,137 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	k8sscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	spannerv1alpha1 "github.com/mercari/spanner-autoscaler/api/v1alpha1"
+	spannerv1beta1 "github.com/mercari/spanner-autoscaler/api/v1beta1"
+)
+
+func spannerEmulatorAddr() string {
+	if v := os.Getenv("SPANNER_EMULATOR_HOST"); v != "" {
+		return v
+	}
+	return "localhost:9010"
+}
+
+func spannerAdminAddr() string {
+	if v := os.Getenv("SPANNER_EMULATOR_ADMIN_ADDR"); v != "" {
+		return v
+	}
+	return "localhost:9011"
+}
+
+func monitoringGRPCAddr() string {
+	if v := os.Getenv("MONITORING_EMULATOR_GRPC_ADDR"); v != "" {
+		return v
+	}
+	return "localhost:9090"
+}
+
+func monitoringAdminAddr() string {
+	if v := os.Getenv("MONITORING_EMULATOR_ADMIN_ADDR"); v != "" {
+		return v
+	}
+	return "localhost:9091"
+}
+
+// repoRoot returns the absolute path to the repository root.
+func repoRoot() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(file), "..", "..")
+}
+
+// createSpannerInstance creates a Spanner instance in the emulator via the admin HTTP API.
+func createSpannerInstance(t *testing.T, projectID, instanceID string, processingUnits int) {
+	t.Helper()
+	body, _ := json.Marshal(map[string]interface{}{"processing_units": processingUnits})
+	url := fmt.Sprintf("http://%s/instances/%s/%s", spannerAdminAddr(), projectID, instanceID)
+	req, err := http.NewRequest(http.MethodPut, url, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("createSpannerInstance: failed to build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("createSpannerInstance %s: %v", url, err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("createSpannerInstance %s: unexpected status %d", url, resp.StatusCode)
+	}
+}
+
+// startEnvtest starts an envtest environment and returns a controller-runtime client.
+// The environment is stopped via t.Cleanup.
+func startEnvtest(t *testing.T) ctrlclient.Client {
+	t.Helper()
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join(repoRoot(), "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+	cfg, err := testEnv.Start()
+	if err != nil {
+		t.Fatalf("failed to start envtest: %v", err)
+	}
+	t.Cleanup(func() { testEnv.Stop() }) //nolint:errcheck
+
+	if err := spannerv1alpha1.AddToScheme(k8sscheme.Scheme); err != nil {
+		t.Fatalf("failed to add v1alpha1 scheme: %v", err)
+	}
+	if err := spannerv1beta1.AddToScheme(k8sscheme.Scheme); err != nil {
+		t.Fatalf("failed to add v1beta1 scheme: %v", err)
+	}
+
+	k8sClient, err := ctrlclient.New(cfg, ctrlclient.Options{Scheme: k8sscheme.Scheme})
+	if err != nil {
+		t.Fatalf("failed to create k8s client: %v", err)
+	}
+	return k8sClient
+}
+
+// adminPUT sends a PUT request to the monitoring emulator admin API.
+func adminPUT(t *testing.T, path string, body []byte) {
+	t.Helper()
+	url := fmt.Sprintf("http://%s%s", monitoringAdminAddr(), path)
+	req, err := http.NewRequest(http.MethodPut, url, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("adminPUT: failed to build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("adminPUT %s: %v", url, err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("adminPUT %s: unexpected status %d", url, resp.StatusCode)
+	}
+}
+
+// adminDELETE sends a DELETE request to the monitoring emulator admin API.
+func adminDELETE(t *testing.T, path string) {
+	t.Helper()
+	url := fmt.Sprintf("http://%s%s", monitoringAdminAddr(), path)
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		t.Fatalf("adminDELETE: failed to build request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("adminDELETE %s: %v", url, err)
+	}
+	resp.Body.Close()
+}

--- a/test/integration/metrics_test.go
+++ b/test/integration/metrics_test.go
@@ -1,0 +1,57 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/mercari/spanner-autoscaler/internal/metrics"
+)
+
+func TestMetricsClient_GetInstanceMetrics_Static(t *testing.T) {
+	const (
+		projectID  = "metrics-project"
+		instanceID = "metrics-instance"
+		wantCPU    = 45 // 0.45 * 100
+	)
+
+	body, _ := json.Marshal(map[string]float64{"cpu_utilization": 0.45})
+	adminPUT(t, fmt.Sprintf("/metrics/%s/%s", projectID, instanceID), body)
+	t.Cleanup(func() { adminDELETE(t, fmt.Sprintf("/metrics/%s/%s", projectID, instanceID)) })
+
+	ctx := context.Background()
+	c, err := metrics.NewClient(ctx, projectID, instanceID,
+		metrics.WithEndpoint(monitoringGRPCAddr()),
+	)
+	if err != nil {
+		t.Fatalf("failed to create metrics client: %v", err)
+	}
+
+	got, err := c.GetInstanceMetrics(ctx)
+	if err != nil {
+		t.Fatalf("GetInstanceMetrics() error: %v", err)
+	}
+
+	if got.CurrentHighPriorityCPUUtilization != wantCPU {
+		t.Errorf("CurrentHighPriorityCPUUtilization = %d, want %d",
+			got.CurrentHighPriorityCPUUtilization, wantCPU)
+	}
+}
+
+func TestMetricsClient_GetInstanceMetrics_NotFound(t *testing.T) {
+	ctx := context.Background()
+	c, err := metrics.NewClient(ctx, "no-project", "no-instance",
+		metrics.WithEndpoint(monitoringGRPCAddr()),
+	)
+	if err != nil {
+		t.Fatalf("failed to create metrics client: %v", err)
+	}
+
+	_, err = c.GetInstanceMetrics(ctx)
+	if err == nil {
+		t.Fatal("GetInstanceMetrics() expected error for unconfigured instance, got nil")
+	}
+}

--- a/test/integration/syncer_test.go
+++ b/test/integration/syncer_test.go
@@ -1,0 +1,122 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/tools/record"
+
+	spannerv1beta1 "github.com/mercari/spanner-autoscaler/api/v1beta1"
+	"github.com/mercari/spanner-autoscaler/internal/metrics"
+	"github.com/mercari/spanner-autoscaler/internal/spanner"
+	"github.com/mercari/spanner-autoscaler/internal/syncer"
+)
+
+func TestSyncer_SyncResource(t *testing.T) {
+	const (
+		projectID  = "syncer-project"
+		instanceID = "syncer-instance"
+		initPU     = 1000
+		wantCPU    = 60 // 0.60 * 100
+	)
+
+	// Configure static CPU utilization in the monitoring emulator.
+	body, _ := json.Marshal(map[string]float64{"cpu_utilization": 0.60})
+	adminPUT(t, fmt.Sprintf("/metrics/%s/%s", projectID, instanceID), body)
+	t.Cleanup(func() { adminDELETE(t, fmt.Sprintf("/metrics/%s/%s", projectID, instanceID)) })
+
+	// Create Spanner instance in the emulator.
+	createSpannerInstance(t, projectID, instanceID, initPU)
+
+	// Start envtest and create K8s client.
+	k8sClient := startEnvtest(t)
+
+	ctx := context.Background()
+	nn := types.NamespacedName{Namespace: "default", Name: "syncer-sa"}
+
+	sa := &spannerv1beta1.SpannerAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nn.Name,
+			Namespace: nn.Namespace,
+		},
+		Spec: spannerv1beta1.SpannerAutoscalerSpec{
+			TargetInstance: spannerv1beta1.TargetInstance{
+				ProjectID:  projectID,
+				InstanceID: instanceID,
+			},
+			Authentication: spannerv1beta1.Authentication{
+				Type: spannerv1beta1.AuthTypeADC,
+			},
+			ScaleConfig: spannerv1beta1.ScaleConfig{
+				ComputeType: spannerv1beta1.ComputeTypePU,
+				ProcessingUnits: spannerv1beta1.ScaleConfigPUs{
+					Min: 100,
+					Max: 10000,
+				},
+				ScaledownStepSize: intstr.FromInt(2000),
+				TargetCPUUtilization: spannerv1beta1.TargetCPUUtilization{
+					HighPriority: 40,
+				},
+			},
+		},
+	}
+	if err := k8sClient.Create(ctx, sa); err != nil {
+		t.Fatalf("failed to create SpannerAutoscaler: %v", err)
+	}
+
+	spannerClient, err := spanner.NewClient(ctx, projectID, instanceID,
+		spanner.WithEndpoint(spannerEmulatorAddr()),
+	)
+	if err != nil {
+		t.Fatalf("failed to create spanner client: %v", err)
+	}
+
+	metricsClient, err := metrics.NewClient(ctx, projectID, instanceID,
+		metrics.WithEndpoint(monitoringGRPCAddr()),
+	)
+	if err != nil {
+		t.Fatalf("failed to create metrics client: %v", err)
+	}
+
+	creds := syncer.NewADCCredentials()
+	recorder := record.NewFakeRecorder(100)
+	s, err := syncer.New(ctx, k8sClient, nn, creds, recorder, spannerClient, metricsClient,
+		syncer.WithInterval(2*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("failed to create syncer: %v", err)
+	}
+
+	go s.Start()
+	t.Cleanup(s.Stop)
+
+	// Wait for the syncer to update status.
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		var updated spannerv1beta1.SpannerAutoscaler
+		if err := k8sClient.Get(ctx, nn, &updated); err != nil {
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+		if updated.Status.CurrentProcessingUnits == initPU &&
+			updated.Status.CurrentHighPriorityCPUUtilization == wantCPU {
+			return // success
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	var updated spannerv1beta1.SpannerAutoscaler
+	k8sClient.Get(ctx, nn, &updated) //nolint:errcheck
+	t.Errorf("syncer did not update status within timeout: PU=%d (want %d), CPU=%d (want %d)",
+		updated.Status.CurrentProcessingUnits, initPU,
+		updated.Status.CurrentHighPriorityCPUUtilization, wantCPU,
+	)
+}

--- a/tilt_config.json.example
+++ b/tilt_config.json.example
@@ -1,0 +1,3 @@
+{
+  "enable_webhooks": false
+}


### PR DESCRIPTION
## What this PR does / Why we need it

### Why we need it

The previous local development experience required manual steps with no emulators: developers had to point the controller at a real GCP project, manage TLS certificates by hand, and apply sample resources themselves. This made it slow to iterate, difficult to onboard new contributors, and impossible to run the full autoscaling loop without real GCP credentials.

###  What this PR does

This PR overhauls the local development environment so that a contributor can go from a fresh clone to a running autoscaling loop with a single command —  no GCP credentials required.

### Spanner and Monitoring emulators

Adds two local emulators managed by docker-compose:

- Spanner emulator — implements only the two Instance Admin RPC methods used by spanner-autoscaler (GetInstance and UpdateInstance), so the controller can read and update processing units against a local process.
- Monitoring emulator — a custom implementation of MetricService.ListTimeSeries (the only Cloud Monitoring RPC spanner-autoscaler calls). Supports three CPU simulation modes checked in priority order: scenario (time-based YAML sequences that loop indefinitely), workload (computes cpu = workload / current_pu, modelling real Spanner scaling behaviour), and static (fixed value). The default scenario drives a full scale-up → stable → scale-down cycle  automatically.

### Tilt integration

A Tiltfile wires everything together:
- Starts both emulators via docker-compose
- Installs cert-manager (first run only), deploys CRDs and webhook configuration
- Extracts TLS certificates and runs the controller locally with live reload on any Go file change
- Creates the Spanner emulator instance and applies a local sample SpannerAutoscaler resource automatically

New make targets: make tilt-up, make tilt-down, make logs-controller, make emulator-up/down, make run-dev, make test-integration.

### Controller and client changes

- --spanner-endpoint and --metrics-endpoint flags allow the controller to connect to local emulators instead of GCP
- ENABLE_WEBHOOKS=false environment variable skips webhook registration for controller-only development
- --cert-dir flag enables local webhook forwarding (used by make run-dev and Tilt)
- WithSpannerClientFactory and WithSyncInterval options were added to support test injection

### Tests

- Integration tests (make test-integration) run the full controller, syncer, and metrics paths against the live emulators
- Webhook validation tests for SpannerAutoscaleSchedule covering create validation and update immutability rules
- Fixed a port 8080 conflict in the controller test suite that occurred when Tilt was already running

### Tool version bumps

Updated kustomize, controller-gen, kind, golangci-lint (v1 → v2), crd-ref-docs, and envtest k8s assets to latest stable versions. Updated .golangci.yml for v2 config key renames.

## Which issue(s) this PR fixes

<!--
    Please specify the related issue.
    If there is no issue related to this PR, first of all you should consider creating an issue.
-->
Fixes #
