### PR TITLE
Bump go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.26 as builder
+FROM golang:1 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/config/crd/bases/spanner.mercari.com_spannerautoscaleschedules.yaml
+++ b/config/crd/bases/spanner.mercari.com_spannerautoscaleschedules.yaml
@@ -52,12 +52,14 @@ spec:
               SpannerAutoscaleSchedule
             properties:
               additionalProcessingUnits:
-                description: The extra compute capacity which will be added when this
-                  schedule is active
+                description: |-
+                  The extra compute capacity which will be added when this schedule is active.
+                  This is the only field that can be updated after creation.
                 type: integer
               schedule:
-                description: The details of when and for how long this schedule will
-                  be active
+                description: |-
+                  The details of when and for how long this schedule will be active.
+                  Immutable after creation.
                 properties:
                   cron:
                     description: 'The recurring frequency of the schedule in [standard
@@ -73,8 +75,9 @@ spec:
                 - duration
                 type: object
               targetResource:
-                description: The `SpannerAutoscaler` resource name with which this
-                  schedule will be registered
+                description: |-
+                  The `SpannerAutoscaler` resource name with which this schedule will be registered.
+                  Immutable after creation.
                 type: string
             required:
             - additionalProcessingUnits

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mercari/spanner-autoscaler
 
-go 1.24
+go 1.26
 
 require (
 	cloud.google.com/go/monitoring v1.18.0


### PR DESCRIPTION
- To fix CI tests: https://github.com/mercari/spanner-autoscaler/actions/runs/24778663336/job/72503555429?pr=220