### PR TITLE
Switch cron library from `robfig/cron` to `netresearch/go-cron`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,6 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version: stable
 
       - run: make test

--- a/Tiltfile
+++ b/Tiltfile
@@ -91,7 +91,7 @@ if ENABLE_WEBHOOKS:
     )
 
 # ── Controller ─────────────────────────────────────────────────────────────────
-EMULATOR_FLAGS = '--spanner-endpoint=localhost:9010 --metrics-endpoint=localhost:9090'
+EMULATOR_FLAGS = '--spanner-endpoint=localhost:9010 --metrics-endpoint=localhost:9090 --leader-elect=false'
 
 # ── Emulator instance setup ────────────────────────────────────────────────────
 # Create the beta-instance in the Spanner emulator and apply the local sample

--- a/api/v1beta1/spannerautoscaleschedule_types.go
+++ b/api/v1beta1/spannerautoscaleschedule_types.go
@@ -40,7 +40,6 @@ type SpannerAutoscaleScheduleSpec struct {
 	AdditionalProcessingUnits int `json:"additionalProcessingUnits"`
 
 	// The details of when and for how long this schedule will be active.
-	// Immutable after creation.
 	Schedule Schedule `json:"schedule"`
 }
 

--- a/api/v1beta1/spannerautoscaleschedule_types.go
+++ b/api/v1beta1/spannerautoscaleschedule_types.go
@@ -36,7 +36,6 @@ type SpannerAutoscaleScheduleSpec struct {
 	TargetResource string `json:"targetResource"`
 
 	// The extra compute capacity which will be added when this schedule is active.
-	// This is the only field that can be updated after creation.
 	AdditionalProcessingUnits int `json:"additionalProcessingUnits"`
 
 	// The details of when and for how long this schedule will be active.

--- a/api/v1beta1/spannerautoscaleschedule_webhook.go
+++ b/api/v1beta1/spannerautoscaleschedule_webhook.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"time"
 
-	cronpkg "github.com/robfig/cron/v3"
+	cronpkg "github.com/netresearch/go-cron"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"

--- a/api/v1beta1/spannerautoscaleschedule_webhook.go
+++ b/api/v1beta1/spannerautoscaleschedule_webhook.go
@@ -81,15 +81,6 @@ func (*spannerAutoscaleScheduleWebhook) ValidateUpdate(_ context.Context, oldObj
 		allErrs = append(allErrs, err)
 	}
 
-	// Disable schedule updates until reconciler is modified to propagate this change to the actual cronjobs
-	if oldObj.Spec.Schedule != newObj.Spec.Schedule {
-		err := field.Invalid(
-			field.NewPath("spec").Child("schedule"),
-			newObj.Spec.Schedule,
-			"'schedule' can not be changed after resource has been created")
-		allErrs = append(allErrs, err)
-	}
-
 	allErrs = append(allErrs, validateSchedule(newObj)...)
 
 	if len(allErrs) == 0 {

--- a/api/v1beta1/spannerautoscaleschedule_webhook_test.go
+++ b/api/v1beta1/spannerautoscaleschedule_webhook_test.go
@@ -93,11 +93,10 @@ var _ = Describe("SpannerAutoscaleSchedule validation", func() {
 		})
 
 		Context("when schedule is changed", func() {
-			It("should return a validation error", func() {
+			It("should not return a validation error", func() {
 				created.Spec.Schedule.Cron = "0 10 * * 1-5"
 				err := k8sClient.Update(ctx, created)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("schedule"))
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 

--- a/config/crd/bases/spanner.mercari.com_spannerautoscaleschedules.yaml
+++ b/config/crd/bases/spanner.mercari.com_spannerautoscaleschedules.yaml
@@ -57,9 +57,8 @@ spec:
                   This is the only field that can be updated after creation.
                 type: integer
               schedule:
-                description: |-
-                  The details of when and for how long this schedule will be active.
-                  Immutable after creation.
+                description: The details of when and for how long this schedule will
+                  be active.
                 properties:
                   cron:
                     description: 'The recurring frequency of the schedule in [standard

--- a/config/crd/bases/spanner.mercari.com_spannerautoscaleschedules.yaml
+++ b/config/crd/bases/spanner.mercari.com_spannerautoscaleschedules.yaml
@@ -52,9 +52,8 @@ spec:
               SpannerAutoscaleSchedule
             properties:
               additionalProcessingUnits:
-                description: |-
-                  The extra compute capacity which will be added when this schedule is active.
-                  This is the only field that can be updated after creation.
+                description: The extra compute capacity which will be added when this
+                  schedule is active.
                 type: integer
               schedule:
                 description: The details of when and for how long this schedule will

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/netresearch/go-cron v0.14.0
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
-	github.com/robfig/cron/v3 v3.0.1
 	go.uber.org/zap v1.27.1
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.20.0

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/golang/protobuf v1.5.4
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
+	github.com/netresearch/go-cron v0.14.0
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
 	github.com/robfig/cron/v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,8 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/netresearch/go-cron v0.14.0 h1:CnUt6kGjet0dQL6rc4xmS+q2EbP9BKR9kh4AX5bnc5U=
+github.com/netresearch/go-cron v0.14.0/go.mod h1:79iktHfV90py3jcaFUtWcGSKbZXRev+WwoLMyV5eMvo=
 github.com/onsi/ginkgo/v2 v2.28.1 h1:S4hj+HbZp40fNKuLUQOYLDgZLwNUVn19N3Atb98NCyI=
 github.com/onsi/ginkgo/v2 v2.28.1/go.mod h1:CLtbVInNckU3/+gC8LzkGUb9oF+e8W8TdUsxPwvdOgE=
 github.com/onsi/gomega v1.39.1 h1:1IJLAad4zjPn2PsnhH70V4DKRFlrCzGBNrNaru+Vf28=
@@ -140,8 +142,6 @@ github.com/prometheus/common v0.66.1 h1:h5E0h5/Y8niHc5DlaLlWLArTQI7tMrsfQjHV+d9Z
 github.com/prometheus/common v0.66.1/go.mod h1:gcaUsgf3KfRSwHY4dIMXLPV0K/Wg1oZ8+SbZk/HH/dA=
 github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
-github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
-github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=

--- a/internal/controller/spannerautoscaler_controller.go
+++ b/internal/controller/spannerautoscaler_controller.go
@@ -507,7 +507,7 @@ func (r *SpannerAutoscalerReconciler) addCronJob(ctx context.Context, log logr.L
 }
 
 func pruneCronJobs(log logr.Logger, sa spannerv1beta1.SpannerAutoscaler, cron *cronpkg.Cron) {
-	// nolint:gocritic (rangeValCopy) — cron.Entries() returns a snapshot, so
+	// gocritic(rangeValCopy): cron.Entries() returns a snapshot, so
 	// calling RemoveByName on the live cron while iterating over the snapshot is safe.
 	for _, entry := range cron.Entries() { //nolint:gocritic
 		job := entry.Job.(schedulerpkg.Job)

--- a/internal/controller/spannerautoscaler_controller.go
+++ b/internal/controller/spannerautoscaler_controller.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	cronpkg "github.com/robfig/cron/v3"
+	cronpkg "github.com/netresearch/go-cron"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,6 +34,7 @@ import (
 	utilclock "k8s.io/utils/clock"
 	ctrlbuilder "sigs.k8s.io/controller-runtime/pkg/builder"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlhandler "sigs.k8s.io/controller-runtime/pkg/handler"
 	ctrlmanager "sigs.k8s.io/controller-runtime/pkg/manager"
 	ctrlreconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -372,8 +373,6 @@ func (r *SpannerAutoscalerReconciler) Reconcile(ctx context.Context, req ctrlrec
 		return ctrlreconcile.Result{}, err
 	}
 
-	// TODO: implement cronjob schedule update whenever SpannerAutoscaleSchedule cron is changed (or block changes to Schedule after creation)
-
 	if cronExists {
 		pruneCronJobs(log, sa, cron)
 	}
@@ -446,6 +445,25 @@ func (r *SpannerAutoscalerReconciler) StopAll() {
 func (r *SpannerAutoscalerReconciler) SetupWithManager(mgr ctrlmanager.Manager) error {
 	return ctrlbuilder.ControllerManagedBy(mgr).
 		For(&spannerv1beta1.SpannerAutoscaler{}).
+		// Watch SpannerAutoscaleSchedule so that edits to its spec (e.g. the
+		// cron expression) enqueue the parent SpannerAutoscaler for reconcile.
+		// Without this, a cron-only change wouldn't touch sa.Status.Schedules
+		// and the in-memory cron entry would never be re-bound.
+		Watches(
+			&spannerv1beta1.SpannerAutoscaleSchedule{},
+			ctrlhandler.EnqueueRequestsFromMapFunc(func(_ context.Context, obj ctrlclient.Object) []ctrlreconcile.Request {
+				sas, ok := obj.(*spannerv1beta1.SpannerAutoscaleSchedule)
+				if !ok || sas.Spec.TargetResource == "" {
+					return nil
+				}
+				return []ctrlreconcile.Request{{
+					NamespacedName: types.NamespacedName{
+						Namespace: sas.Namespace,
+						Name:      sas.Spec.TargetResource,
+					},
+				}}
+			}),
+		).
 		Complete(r)
 }
 
@@ -457,20 +475,25 @@ func (r *SpannerAutoscalerReconciler) addCronJob(ctx context.Context, log logr.L
 		if err := r.ctrlClient.Get(ctx, nnsas, &sas); err != nil {
 			log.Error(err, "failed to get spanner-autoscaler-schedule")
 			return err
-		} else {
-			job := schedulerpkg.Job{
-				ScheduleName:   nnsas,
-				AutoscalerName: nnsa,
-				Log:            log.WithName("job").WithValues("schedule", nnsas, "autoscaler", nnsa),
-				CtrlClient:     r.ctrlClient,
-			}
-			if !jobExists(cron, job) {
-				if _, err := cron.AddJob(sas.Spec.Schedule.Cron, job); err != nil {
-					log.Error(err, "failed to add cron job to the cron")
-				}
-				log.Info("new cron job has been registered", "cron", sas.Spec.Schedule.Cron, "schedule", nnsas.String())
-			}
 		}
+
+		job := schedulerpkg.Job{
+			ScheduleName:   nnsas,
+			AutoscalerName: nnsa,
+			Cron:           sas.Spec.Schedule.Cron,
+			Log:            log.WithName("job").WithValues("schedule", nnsas, "autoscaler", nnsa),
+			CtrlClient:     r.ctrlClient,
+		}
+		// UpsertJob (keyed by WithName) atomically replaces the schedule when
+		// sas.Spec.Schedule.Cron has changed; otherwise it creates a new entry.
+		// The new spec is parsed before the existing entry is touched, so an
+		// invalid expression leaves the previous schedule intact.
+		if _, err := cron.UpsertJob(sas.Spec.Schedule.Cron, job, cronpkg.WithName(nnsas.String())); err != nil {
+			log.Error(err, "failed to upsert cron job", "cron", sas.Spec.Schedule.Cron, "schedule", nnsas.String())
+			r.recorder.Event(&sas, corev1.EventTypeWarning, "InvalidCronExpression", err.Error())
+			continue
+		}
+		log.V(1).Info("cron job upserted", "cron", sas.Spec.Schedule.Cron, "schedule", nnsas.String())
 	}
 	return nil
 }
@@ -479,8 +502,8 @@ func pruneCronJobs(log logr.Logger, sa spannerv1beta1.SpannerAutoscaler, cron *c
 	for _, entry := range cron.Entries() {
 		job := entry.Job.(schedulerpkg.Job)
 		if _, found := findInArray(sa.Status.Schedules, job.ScheduleName.String()); !found {
-			cron.Remove(entry.ID)
-			log.V(1).Info("removed cron job", "job", job, "cronjob-count", len(cron.Entries()))
+			cron.RemoveByName(entry.Name)
+			log.V(1).Info("removed cron job", "cron", job.Cron, "schedule", entry.Name, "cronjob-count", len(cron.Entries()))
 		}
 	}
 }
@@ -497,16 +520,6 @@ func pruneActiveSchedules(log logr.Logger, sa spannerv1beta1.SpannerAutoscaler) 
 		result = append(result, as)
 	}
 	return result, changed
-}
-
-func jobExists(cron *cronpkg.Cron, job schedulerpkg.Job) bool {
-	for _, e := range cron.Entries() {
-		entryJob := e.Job.(schedulerpkg.Job)
-		if entryJob.ScheduleName == job.ScheduleName {
-			return true
-		}
-	}
-	return false
 }
 
 // TODO: move this (and other similar functions) to 'internal/util' package

--- a/internal/controller/spannerautoscaler_controller.go
+++ b/internal/controller/spannerautoscaler_controller.go
@@ -457,6 +457,9 @@ func (r *SpannerAutoscalerReconciler) SetupWithManager(mgr ctrlmanager.Manager) 
 					return nil
 				}
 				return []ctrlreconcile.Request{{
+					// SpannerAutoscaleSchedule and SpannerAutoscaler are assumed to
+					// always reside in the same namespace; TargetResource is a plain
+					// name (not namespaced), so we inherit the schedule's namespace.
 					NamespacedName: types.NamespacedName{
 						Namespace: sas.Namespace,
 						Name:      sas.Spec.TargetResource,
@@ -491,6 +494,11 @@ func (r *SpannerAutoscalerReconciler) addCronJob(ctx context.Context, log logr.L
 		if _, err := cron.UpsertJob(sas.Spec.Schedule.Cron, job, cronpkg.WithName(nnsas.String())); err != nil {
 			log.Error(err, "failed to upsert cron job", "cron", sas.Spec.Schedule.Cron, "schedule", nnsas.String())
 			r.recorder.Event(&sas, corev1.EventTypeWarning, "InvalidCronExpression", err.Error())
+			// Intentionally using continue rather than returning the error: a bad cron
+			// expression on one schedule should not block the remaining schedules from
+			// being registered. The reconciler will retry when the user corrects the
+			// expression (the Watch on SpannerAutoscaleSchedule will trigger a new
+			// reconcile on the next update).
 			continue
 		}
 		log.V(1).Info("cron job upserted", "cron", sas.Spec.Schedule.Cron, "schedule", nnsas.String())
@@ -499,9 +507,15 @@ func (r *SpannerAutoscalerReconciler) addCronJob(ctx context.Context, log logr.L
 }
 
 func pruneCronJobs(log logr.Logger, sa spannerv1beta1.SpannerAutoscaler, cron *cronpkg.Cron) {
+	// nolint:gocritic (rangeValCopy) — cron.Entries() returns a snapshot, so
+	// calling RemoveByName on the live cron while iterating over the snapshot is safe.
 	for _, entry := range cron.Entries() { //nolint:gocritic
 		job := entry.Job.(schedulerpkg.Job)
 		if _, found := findInArray(sa.Status.Schedules, job.ScheduleName.String()); !found {
+			if entry.Name == "" {
+				log.Error(nil, "cron entry has no name, skipping removal", "job", job.ScheduleName)
+				continue
+			}
 			cron.RemoveByName(entry.Name)
 			log.V(1).Info("removed cron job", "cron", job.Cron, "schedule", entry.Name, "cronjob-count", len(cron.Entries()))
 		}

--- a/internal/controller/spannerautoscaler_controller.go
+++ b/internal/controller/spannerautoscaler_controller.go
@@ -499,7 +499,7 @@ func (r *SpannerAutoscalerReconciler) addCronJob(ctx context.Context, log logr.L
 }
 
 func pruneCronJobs(log logr.Logger, sa spannerv1beta1.SpannerAutoscaler, cron *cronpkg.Cron) {
-	for _, entry := range cron.Entries() {
+	for _, entry := range cron.Entries() { //nolint:gocritic
 		job := entry.Job.(schedulerpkg.Job)
 		if _, found := findInArray(sa.Status.Schedules, job.ScheduleName.String()); !found {
 			cron.RemoveByName(entry.Name)

--- a/internal/controller/spannerautoscaler_controller_test.go
+++ b/internal/controller/spannerautoscaler_controller_test.go
@@ -3,17 +3,24 @@ package controller
 import (
 	"time"
 
+	cronpkg "github.com/netresearch/go-cron"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	testingclock "k8s.io/utils/clock/testing"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	spannerv1beta1 "github.com/mercari/spanner-autoscaler/api/v1beta1"
+	schedulerpkg "github.com/mercari/spanner-autoscaler/internal/scheduler"
 	"github.com/mercari/spanner-autoscaler/internal/syncer"
+	fakesyncer "github.com/mercari/spanner-autoscaler/internal/syncer/fake"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -635,3 +642,229 @@ var _ = Describe("Calculate Desired PU Range", func() {
 })
 
 func intPtr(i int) *int { return &i }
+
+var _ = Describe("Cron mutability", func() {
+	Describe("addCronJob", func() {
+		var (
+			cronInst     *cronpkg.Cron
+			fakeRecorder *record.FakeRecorder
+			reconciler   *SpannerAutoscalerReconciler
+		)
+
+		BeforeEach(func() {
+			cronInst = cronpkg.New()
+			cronInst.Start()
+			fakeRecorder = record.NewFakeRecorder(10)
+			reconciler = &SpannerAutoscalerReconciler{
+				recorder: fakeRecorder,
+				log:      logr.Discard(),
+			}
+		})
+
+		AfterEach(func() {
+			cronInst.Stop()
+		})
+
+		makeSchedule := func(nn types.NamespacedName, expr string) *spannerv1beta1.SpannerAutoscaleSchedule {
+			return &spannerv1beta1.SpannerAutoscaleSchedule{
+				ObjectMeta: metav1.ObjectMeta{Name: nn.Name, Namespace: nn.Namespace},
+				Spec: spannerv1beta1.SpannerAutoscaleScheduleSpec{
+					TargetResource:            "test-sa",
+					AdditionalProcessingUnits: 1000,
+					Schedule: spannerv1beta1.Schedule{
+						Cron:     expr,
+						Duration: "1h",
+					},
+				},
+			}
+		}
+
+		saFor := func(saNN, schedNN types.NamespacedName) spannerv1beta1.SpannerAutoscaler {
+			return spannerv1beta1.SpannerAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{Name: saNN.Name, Namespace: saNN.Namespace},
+				Status: spannerv1beta1.SpannerAutoscalerStatus{
+					Schedules: []string{schedNN.String()},
+				},
+			}
+		}
+
+		It("registers a new cron entry for a new schedule", func() {
+			schedNN := types.NamespacedName{Namespace: "default", Name: "sched-new"}
+			saNN := types.NamespacedName{Namespace: "default", Name: "sa-new"}
+
+			fc := fakeclient.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(makeSchedule(schedNN, "0 * * * *")).Build()
+			reconciler.ctrlClient = fc
+
+			Expect(reconciler.addCronJob(ctx, logr.Discard(), saFor(saNN, schedNN), cronInst)).To(Succeed())
+			Expect(cronInst.Entries()).To(HaveLen(1))
+			Expect(cronInst.Entries()[0].Job.(schedulerpkg.Job).Cron).To(Equal("0 * * * *"))
+		})
+
+		It("replaces the cron entry when the expression changes", func() {
+			schedNN := types.NamespacedName{Namespace: "default", Name: "sched-update"}
+			saNN := types.NamespacedName{Namespace: "default", Name: "sa-update"}
+
+			sas := makeSchedule(schedNN, "0 * * * *")
+			fc := fakeclient.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(sas).Build()
+			reconciler.ctrlClient = fc
+			sa := saFor(saNN, schedNN)
+
+			Expect(reconciler.addCronJob(ctx, logr.Discard(), sa, cronInst)).To(Succeed())
+			Expect(cronInst.Entries()).To(HaveLen(1))
+
+			updated := sas.DeepCopy()
+			updated.Spec.Schedule.Cron = "30 * * * *"
+			Expect(fc.Update(ctx, updated)).To(Succeed())
+
+			Expect(reconciler.addCronJob(ctx, logr.Discard(), sa, cronInst)).To(Succeed())
+			Expect(cronInst.Entries()).To(HaveLen(1), "upsert must not create a duplicate entry")
+			Expect(cronInst.Entries()[0].Job.(schedulerpkg.Job).Cron).To(Equal("30 * * * *"))
+		})
+
+		It("keeps the existing entry and emits a Warning on an invalid cron expression", func() {
+			schedNN := types.NamespacedName{Namespace: "default", Name: "sched-invalid"}
+			saNN := types.NamespacedName{Namespace: "default", Name: "sa-invalid"}
+
+			sas := makeSchedule(schedNN, "0 * * * *")
+			fc := fakeclient.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(sas).Build()
+			reconciler.ctrlClient = fc
+			sa := saFor(saNN, schedNN)
+
+			Expect(reconciler.addCronJob(ctx, logr.Discard(), sa, cronInst)).To(Succeed())
+			Expect(cronInst.Entries()).To(HaveLen(1))
+
+			updated := sas.DeepCopy()
+			updated.Spec.Schedule.Cron = "not-a-cron"
+			Expect(fc.Update(ctx, updated)).To(Succeed())
+
+			Expect(reconciler.addCronJob(ctx, logr.Discard(), sa, cronInst)).To(Succeed())
+			Expect(cronInst.Entries()).To(HaveLen(1), "invalid expression must leave existing entry intact")
+			Expect(cronInst.Entries()[0].Job.(schedulerpkg.Job).Cron).To(Equal("0 * * * *"))
+			Expect(fakeRecorder.Events).To(Receive(ContainSubstring("InvalidCronExpression")))
+		})
+	})
+
+	Describe("pruneCronJobs", func() {
+		It("removes entries no longer listed in sa.Status.Schedules", func() {
+			cronInst := cronpkg.New()
+			cronInst.Start()
+			DeferCleanup(cronInst.Stop)
+
+			keepNN := types.NamespacedName{Namespace: "default", Name: "sched-keep"}
+			removeNN := types.NamespacedName{Namespace: "default", Name: "sched-remove"}
+
+			for _, pair := range []struct {
+				nn   types.NamespacedName
+				expr string
+			}{
+				{keepNN, "0 * * * *"},
+				{removeNN, "30 * * * *"},
+			} {
+				job := schedulerpkg.Job{ScheduleName: pair.nn, Cron: pair.expr}
+				_, err := cronInst.UpsertJob(pair.expr, job, cronpkg.WithName(pair.nn.String()))
+				Expect(err).NotTo(HaveOccurred())
+			}
+			Expect(cronInst.Entries()).To(HaveLen(2))
+
+			sa := spannerv1beta1.SpannerAutoscaler{
+				Status: spannerv1beta1.SpannerAutoscalerStatus{
+					Schedules: []string{keepNN.String()},
+				},
+			}
+			pruneCronJobs(logr.Discard(), sa, cronInst)
+
+			Expect(cronInst.Entries()).To(HaveLen(1))
+			Expect(cronInst.Entries()[0].Job.(schedulerpkg.Job).ScheduleName).To(Equal(keepNN))
+		})
+	})
+
+	Context("envtest: SpannerAutoscaleSchedule cron update triggers reconcile", func() {
+		It("replaces the in-memory cron entry when spec.schedule.cron is updated", func() {
+			saName := "test-cron-mut-" + uuid.NewString()[:8]
+			schedName := "sched-" + uuid.NewString()[:8]
+			saNN := types.NamespacedName{Namespace: namespace, Name: saName}
+			schedNN := types.NamespacedName{Namespace: namespace, Name: schedName}
+
+			By("pre-seeding a fake syncer so reconcile bypasses syncer creation")
+			spReconciler.mu.Lock()
+			spReconciler.syncers[saNN] = &fakesyncer.Syncer{}
+			spReconciler.mu.Unlock()
+
+			By("creating the SpannerAutoscaleSchedule with initial cron '0 * * * *'")
+			sched := &spannerv1beta1.SpannerAutoscaleSchedule{
+				ObjectMeta: metav1.ObjectMeta{Name: schedName, Namespace: namespace},
+				Spec: spannerv1beta1.SpannerAutoscaleScheduleSpec{
+					TargetResource:            saName,
+					AdditionalProcessingUnits: 1000,
+					Schedule: spannerv1beta1.Schedule{
+						Cron:     "0 * * * *",
+						Duration: "1h",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, sched)).To(Succeed())
+
+			By("creating the SpannerAutoscaler")
+			sa := &spannerv1beta1.SpannerAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{Name: saName, Namespace: namespace},
+				Spec: spannerv1beta1.SpannerAutoscalerSpec{
+					TargetInstance: spannerv1beta1.TargetInstance{
+						ProjectID:  "test-proj",
+						InstanceID: "test-inst",
+					},
+					Authentication: spannerv1beta1.Authentication{
+						Type: spannerv1beta1.AuthTypeADC,
+					},
+					ScaleConfig: spannerv1beta1.ScaleConfig{
+						ComputeType: spannerv1beta1.ComputeTypePU,
+						ProcessingUnits: spannerv1beta1.ScaleConfigPUs{
+							Min: 100,
+							Max: 1000,
+						},
+						ScaledownStepSize: intstr.FromInt(100),
+						TargetCPUUtilization: spannerv1beta1.TargetCPUUtilization{
+							HighPriority: intPtr(40),
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, sa)).To(Succeed())
+
+			By("setting Status.Schedules to include the schedule")
+			sa.Status.Schedules = []string{schedNN.String()}
+			Expect(k8sClient.Status().Update(ctx, sa)).To(Succeed())
+
+			By("waiting for the initial cron entry to be registered")
+			Eventually(func() string {
+				spReconciler.mu.RLock()
+				c, ok := spReconciler.crons[saNN]
+				spReconciler.mu.RUnlock()
+				if !ok || len(c.Entries()) == 0 {
+					return ""
+				}
+				return c.Entries()[0].Job.(schedulerpkg.Job).Cron
+			}, 5*time.Second, 200*time.Millisecond).Should(Equal("0 * * * *"))
+
+			By("updating spec.schedule.cron to '30 * * * *'")
+			Expect(k8sClient.Get(ctx, schedNN, sched)).To(Succeed())
+			sched.Spec.Schedule.Cron = "30 * * * *"
+			Expect(k8sClient.Update(ctx, sched)).To(Succeed())
+
+			By("waiting for the in-memory cron entry to reflect the new expression")
+			Eventually(func() string {
+				spReconciler.mu.RLock()
+				c, ok := spReconciler.crons[saNN]
+				spReconciler.mu.RUnlock()
+				if !ok || len(c.Entries()) == 0 {
+					return ""
+				}
+				return c.Entries()[0].Job.(schedulerpkg.Job).Cron
+			}, 5*time.Second, 200*time.Millisecond).Should(Equal("30 * * * *"))
+
+			spReconciler.mu.RLock()
+			entryCount := len(spReconciler.crons[saNN].Entries())
+			spReconciler.mu.RUnlock()
+			Expect(entryCount).To(Equal(1), "upsert must not duplicate the entry")
+		})
+	})
+})

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/go-logr/logr"
 	spannerv1beta1 "github.com/mercari/spanner-autoscaler/api/v1beta1"
-	cronpkg "github.com/robfig/cron/v3"
+	cronpkg "github.com/netresearch/go-cron"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
@@ -33,8 +33,12 @@ type scheduler struct {
 type Job struct {
 	ScheduleName   types.NamespacedName
 	AutoscalerName types.NamespacedName
-	Log            logr.Logger
-	CtrlClient     ctrlclient.Client
+	// Cron is the spec string this job was registered with. Stored so that
+	// log lines (e.g. on prune) can surface the original expression — the
+	// cron library only retains the parsed Schedule, not the spec text.
+	Cron       string
+	Log        logr.Logger
+	CtrlClient ctrlclient.Client
 }
 
 func New(log logr.Logger, ctrlClient ctrlclient.Client, crons map[types.NamespacedName]*cronpkg.Cron, autoscalerName types.NamespacedName) scheduler {

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/mercari/spanner-autoscaler/tools
 
-go 1.26.2
+go 1.26
 
 require (
 	github.com/elastic/crd-ref-docs v0.3.0


### PR DESCRIPTION
 ## Summary
  Replace the unmaintained `robfig/cron` library (last released more than 6 years ago) with a more recently maintained alternative: `netresearch/go-cron`.
  This also makes `SpannerAutoscaleSchedule.spec.schedule.cron` mutable, because the new library adds `UpsertJob` and named-entry support for live cron expression updates without a restart.

  ## Changes

  - **Webhook**: removed the `ValidateUpdate` guard that blocked `spec.schedule` edits
  - **Controller**: replaced `AddJob`+`jobExists` with `UpsertJob` (keyed by entry name)
    so a changed cron expression atomically replaces the running entry; invalid expressions
    emit a `Warning` event and leave the previous schedule intact
  - **Controller**: added a `Watches` on `SpannerAutoscaleSchedule` so spec-only edits
    enqueue the parent `SpannerAutoscaler` for reconcile
  - **Scheduler**: added `Cron string` to `Job` to preserve the raw spec for log output
  - **Tiltfile**: added `--leader-elect=false` for single-node local runs

  ## Testing

  - Updated webhook test to assert that updating `spec.schedule.cron` succeeds instead
  of returning a validation error.
  - Verified locally that schedule change is correctly applied without controller restart