### PR TITLE
feat: make highPriority optional, add total-only CPU scaling mode

### DIFF
--- a/api/v1beta1/spannerautoscaler_types.go
+++ b/api/v1beta1/spannerautoscaler_types.go
@@ -37,6 +37,29 @@ const (
 	CPUMetricTypeBoth CPUMetricType = "Both"
 )
 
+// CPUMetricFlags is a bitmask of which CPU metric thresholds are active.
+// Each bit corresponds to one metric in TargetCPUUtilization.
+// New metrics can be added by defining additional bit constants below.
+type CPUMetricFlags uint8
+
+const (
+	CPUMetricFlagHighPriority CPUMetricFlags = 1 << iota
+	CPUMetricFlagTotal
+)
+
+// ActiveMetricFlags returns a bitmask representing which CPU metric thresholds
+// are configured (non-nil) in this TargetCPUUtilization.
+func (c TargetCPUUtilization) ActiveMetricFlags() CPUMetricFlags {
+	var f CPUMetricFlags
+	if c.HighPriority != nil {
+		f |= CPUMetricFlagHighPriority
+	}
+	if c.Total != nil {
+		f |= CPUMetricFlagTotal
+	}
+	return f
+}
+
 // Type for specifying authentication methods
 // +kubebuilder:validation:Enum=gcp-sa-key;impersonation;adc
 type AuthType string
@@ -161,15 +184,18 @@ type ScaleConfigPUs struct {
 
 type TargetCPUUtilization struct {
 	// Desired CPU utilization for 'High Priority' CPU consumption category. Ref: [Spanner CPU utilization](https://cloud.google.com/spanner/docs/cpu-utilization#task-priority)
-	// Required. When specified together with 'total', scale-out occurs when either threshold is exceeded (OR condition).
+	// Optional. When specified together with 'total', scale-out occurs when either threshold is exceeded (OR condition).
+	// At least one of 'highPriority' or 'total' must be specified.
+	// +optional
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=100
 	// +kubebuilder:validation:ExclusiveMinimum=true
 	// +kubebuilder:validation:ExclusiveMaximum=true
-	HighPriority *int `json:"highPriority"`
+	HighPriority *int `json:"highPriority,omitempty"`
 
 	// Desired total CPU utilization (all priorities combined). Ref: [Spanner CPU utilization](https://cloud.google.com/spanner/docs/cpu-utilization)
 	// Optional. When specified together with 'highPriority', scale-out occurs when either threshold is exceeded (OR condition).
+	// At least one of 'highPriority' or 'total' must be specified.
 	// +optional
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=100

--- a/api/v1beta1/spannerautoscaler_types.go
+++ b/api/v1beta1/spannerautoscaler_types.go
@@ -37,29 +37,6 @@ const (
 	CPUMetricTypeBoth CPUMetricType = "Both"
 )
 
-// CPUMetricFlags is a bitmask of which CPU metric thresholds are active.
-// Each bit corresponds to one metric in TargetCPUUtilization.
-// New metrics can be added by defining additional bit constants below.
-type CPUMetricFlags uint8
-
-const (
-	CPUMetricFlagHighPriority CPUMetricFlags = 1 << iota
-	CPUMetricFlagTotal
-)
-
-// ActiveMetricFlags returns a bitmask representing which CPU metric thresholds
-// are configured (non-nil) in this TargetCPUUtilization.
-func (c TargetCPUUtilization) ActiveMetricFlags() CPUMetricFlags {
-	var f CPUMetricFlags
-	if c.HighPriority != nil {
-		f |= CPUMetricFlagHighPriority
-	}
-	if c.Total != nil {
-		f |= CPUMetricFlagTotal
-	}
-	return f
-}
-
 // Type for specifying authentication methods
 // +kubebuilder:validation:Enum=gcp-sa-key;impersonation;adc
 type AuthType string
@@ -202,6 +179,29 @@ type TargetCPUUtilization struct {
 	// +kubebuilder:validation:ExclusiveMinimum=true
 	// +kubebuilder:validation:ExclusiveMaximum=true
 	Total *int `json:"total,omitempty"`
+}
+
+// CPUMetricFlags is a bitmask of which CPU metric thresholds are active.
+// Each bit corresponds to one metric in TargetCPUUtilization.
+// New metrics can be added by defining additional bit constants below.
+type CPUMetricFlags uint8
+
+const (
+	CPUMetricFlagHighPriority CPUMetricFlags = 1 << iota
+	CPUMetricFlagTotal
+)
+
+// ActiveMetricFlags returns a bitmask representing which CPU metric thresholds
+// are configured (non-nil) in this TargetCPUUtilization.
+func (c TargetCPUUtilization) ActiveMetricFlags() CPUMetricFlags {
+	var f CPUMetricFlags
+	if c.HighPriority != nil {
+		f |= CPUMetricFlagHighPriority
+	}
+	if c.Total != nil {
+		f |= CPUMetricFlagTotal
+	}
+	return f
 }
 
 // SpannerAutoscalerSpec defines the desired state of SpannerAutoscaler

--- a/api/v1beta1/spannerautoscaler_webhook.go
+++ b/api/v1beta1/spannerautoscaler_webhook.go
@@ -167,12 +167,10 @@ func validateAuthentication(r *SpannerAutoscaler) *field.Error {
 }
 
 func validateTargetCPUUtilization(cpu TargetCPUUtilization) *field.Error {
-	// highPriority is required. total is optional and can be combined with highPriority
-	// for dual CPU scaling (scale-out when either threshold is exceeded).
-	if cpu.HighPriority == nil {
+	if cpu.HighPriority == nil && cpu.Total == nil {
 		return field.Required(
-			field.NewPath("spec", "scaleConfig", "targetCPUUtilization", "highPriority"),
-			"'highPriority' is required; 'total' may be specified additionally for dual CPU scaling",
+			field.NewPath("spec", "scaleConfig", "targetCPUUtilization"),
+			"at least one of 'highPriority' or 'total' must be specified",
 		)
 	}
 	return nil

--- a/api/v1beta1/spannerautoscaler_webhook_test.go
+++ b/api/v1beta1/spannerautoscaler_webhook_test.go
@@ -233,12 +233,9 @@ var _ = Describe("SpannerAutoscaler validation", func() {
 					}
 				})
 
-				// highPriority is required. When nil, the CRD schema validation rejects null
-				// before the webhook runs, producing an "invalid type" error.
-				It("should return validation error", func() {
+				It("should succeed (total-only mode)", func() {
 					_, err := createResource(testResource)
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("targetCPUUtilization.highPriority"))
+					Expect(err).ToNot(HaveOccurred())
 				})
 			})
 
@@ -261,12 +258,10 @@ var _ = Describe("SpannerAutoscaler validation", func() {
 					testResource.Spec.ScaleConfig.TargetCPUUtilization = TargetCPUUtilization{}
 				})
 
-				// highPriority is required. When nil, the CRD schema validation rejects null
-				// before the webhook runs, producing an "invalid type" error.
 				It("should return validation error", func() {
 					_, err := createResource(testResource)
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("targetCPUUtilization.highPriority"))
+					Expect(err.Error()).To(ContainSubstring("at least one of 'highPriority' or 'total' must be specified"))
 				})
 			})
 		})

--- a/config/crd/bases/spanner.mercari.com_spannerautoscalers.yaml
+++ b/config/crd/bases/spanner.mercari.com_spannerautoscalers.yaml
@@ -402,7 +402,8 @@ spec:
                       highPriority:
                         description: |-
                           Desired CPU utilization for 'High Priority' CPU consumption category. Ref: [Spanner CPU utilization](https://cloud.google.com/spanner/docs/cpu-utilization#task-priority)
-                          Required. When specified together with 'total', scale-out occurs when either threshold is exceeded (OR condition).
+                          Optional. When specified together with 'total', scale-out occurs when either threshold is exceeded (OR condition).
+                          At least one of 'highPriority' or 'total' must be specified.
                         exclusiveMaximum: true
                         exclusiveMinimum: true
                         maximum: 100
@@ -412,13 +413,12 @@ spec:
                         description: |-
                           Desired total CPU utilization (all priorities combined). Ref: [Spanner CPU utilization](https://cloud.google.com/spanner/docs/cpu-utilization)
                           Optional. When specified together with 'highPriority', scale-out occurs when either threshold is exceeded (OR condition).
+                          At least one of 'highPriority' or 'total' must be specified.
                         exclusiveMaximum: true
                         exclusiveMinimum: true
                         maximum: 100
                         minimum: 0
                         type: integer
-                    required:
-                    - highPriority
                     type: object
                 required:
                 - targetCPUUtilization

--- a/config/crd/bases/spanner.mercari.com_spannerautoscaleschedules.yaml
+++ b/config/crd/bases/spanner.mercari.com_spannerautoscaleschedules.yaml
@@ -60,9 +60,10 @@ spec:
                   be active.
                 properties:
                   cron:
-                    description: 'The recurring frequency of the schedule in [standard
-                      cron](https://en.wikipedia.org/wiki/Cron) format. Examples and
-                      verification utility: https://crontab.guru'
+                    description: |-
+                      The recurring frequency of the schedule in [standard cron](https://en.wikipedia.org/wiki/Cron) format.
+                      Extended syntax (`L`, `L-n`, `nW`, `LW`, `DAY#n`, `DAY#L`) is also supported — see [go-cron Extended Syntax](https://pkg.go.dev/github.com/netresearch/go-cron#hdr-Extended_Syntax__Optional_).
+                      Examples and verification utility: https://crontab.guru
                     type: string
                   duration:
                     description: The length of time for which this schedule will remain

--- a/docs/crd-reference.md
+++ b/docs/crd-reference.md
@@ -69,6 +69,8 @@ _Appears in:_
 | `iamKeySecret` _[IAMKeySecret](#iamkeysecret)_ | Details of the k8s secret which contains the GCP service account authentication key (in JSON).<br />[[Ref](https://cloud.google.com/kubernetes-engine/docs/tutorials/authenticating-to-cloud-platform)].<br />This is a pointer because structs with string slices can not be compared for zero values |  |  |
 
 
+
+
 #### CPUMetricType
 
 _Underlying type:_ _string_
@@ -361,8 +363,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `highPriority` _integer_ | Desired CPU utilization for 'High Priority' CPU consumption category. Ref: [Spanner CPU utilization](https://cloud.google.com/spanner/docs/cpu-utilization#task-priority)<br />Required. When specified together with 'total', scale-out occurs when either threshold is exceeded (OR condition). |  | ExclusiveMaximum: true <br />ExclusiveMinimum: true <br />Maximum: 100 <br />Minimum: 0 <br /> |
-| `total` _integer_ | Desired total CPU utilization (all priorities combined). Ref: [Spanner CPU utilization](https://cloud.google.com/spanner/docs/cpu-utilization)<br />Optional. When specified together with 'highPriority', scale-out occurs when either threshold is exceeded (OR condition). |  | ExclusiveMaximum: true <br />ExclusiveMinimum: true <br />Maximum: 100 <br />Minimum: 0 <br />Optional: \{\} <br /> |
+| `highPriority` _integer_ | Desired CPU utilization for 'High Priority' CPU consumption category. Ref: [Spanner CPU utilization](https://cloud.google.com/spanner/docs/cpu-utilization#task-priority)<br />Optional. When specified together with 'total', scale-out occurs when either threshold is exceeded (OR condition).<br />At least one of 'highPriority' or 'total' must be specified. |  | ExclusiveMaximum: true <br />ExclusiveMinimum: true <br />Maximum: 100 <br />Minimum: 0 <br />Optional: \{\} <br /> |
+| `total` _integer_ | Desired total CPU utilization (all priorities combined). Ref: [Spanner CPU utilization](https://cloud.google.com/spanner/docs/cpu-utilization)<br />Optional. When specified together with 'highPriority', scale-out occurs when either threshold is exceeded (OR condition).<br />At least one of 'highPriority' or 'total' must be specified. |  | ExclusiveMaximum: true <br />ExclusiveMinimum: true <br />Maximum: 100 <br />Minimum: 0 <br />Optional: \{\} <br /> |
 
 
 #### TargetInstance

--- a/internal/controller/spannerautoscaler_controller.go
+++ b/internal/controller/spannerautoscaler_controller.go
@@ -650,11 +650,9 @@ func (r *SpannerAutoscalerReconciler) needUpdateProcessingUnits(log logr.Logger,
 
 // calcDesiredProcessingUnits calculates the values needed to keep CPU utilization below TargetCPU.
 func calcDesiredProcessingUnits(sa spannerv1beta1.SpannerAutoscaler) int {
-	// Dual CPU scaling mode: both highPriority and total are specified.
-	// Calculate desired PU for each metric independently and take the maximum
-	// so that scale-out occurs when either threshold is exceeded.
-	if sa.Spec.ScaleConfig.TargetCPUUtilization.HighPriority != nil &&
-		sa.Spec.ScaleConfig.TargetCPUUtilization.Total != nil {
+	switch sa.Spec.ScaleConfig.TargetCPUUtilization.ActiveMetricFlags() {
+	case spannerv1beta1.CPUMetricFlagHighPriority | spannerv1beta1.CPUMetricFlagTotal:
+		// Dual mode: scale-out when either threshold is exceeded (OR condition).
 		// Guard: wait until syncer has populated both metrics in status.
 		if sa.Status.CurrentCPUMetricType != spannerv1beta1.CPUMetricTypeBoth {
 			return sa.Status.CurrentProcessingUnits
@@ -673,28 +671,37 @@ func calcDesiredProcessingUnits(sa spannerv1beta1.SpannerAutoscaler) int {
 			return desiredByHigh
 		}
 		return desiredByTotal
-	}
 
-	// Single mode: highPriority only (total-only is no longer supported).
-	if sa.Spec.ScaleConfig.TargetCPUUtilization.HighPriority == nil {
-		// Defensively handle invalid specs when admission validation is bypassed
-		// or malformed objects already exist in-cluster.
+	case spannerv1beta1.CPUMetricFlagTotal:
+		// If the status was last synced for a different metric type, skip this reconcile.
+		if sa.Status.CurrentCPUMetricType != spannerv1beta1.CPUMetricTypeTotal {
+			return sa.Status.CurrentProcessingUnits
+		}
+		return calcDesiredPUFromCPU(
+			sa.Status.CurrentTotalCPUUtilization,
+			*sa.Spec.ScaleConfig.TargetCPUUtilization.Total,
+			sa,
+		)
+
+	case spannerv1beta1.CPUMetricFlagHighPriority:
+		// If the status was last synced for a different metric type, the CPU value
+		// in status belongs to the old metric and cannot be used for scaling decisions.
+		// Skip this reconcile; the syncer will update CurrentCPUMetricType within one
+		// sync cycle (≤1 minute).
+		if sa.Status.CurrentCPUMetricType != spannerv1beta1.CPUMetricTypeHighPriority {
+			return sa.Status.CurrentProcessingUnits
+		}
+		return calcDesiredPUFromCPU(
+			sa.Status.CurrentHighPriorityCPUUtilization,
+			*sa.Spec.ScaleConfig.TargetCPUUtilization.HighPriority,
+			sa,
+		)
+
+	default:
+		// No metric configured — invalid spec that bypassed webhook validation,
+		// or malformed objects already existing in-cluster. Hold current PU.
 		return sa.Status.CurrentProcessingUnits
 	}
-
-	// If the status was last synced for a different metric type, the CPU value
-	// in status belongs to the old metric and cannot be used for scaling decisions.
-	// Skip this reconcile; the syncer will update CurrentCPUMetricType within one
-	// sync cycle (≤1 minute).
-	if sa.Status.CurrentCPUMetricType != spannerv1beta1.CPUMetricTypeHighPriority {
-		return sa.Status.CurrentProcessingUnits
-	}
-
-	return calcDesiredPUFromCPU(
-		sa.Status.CurrentHighPriorityCPUUtilization,
-		*sa.Spec.ScaleConfig.TargetCPUUtilization.HighPriority,
-		sa,
-	)
 }
 
 // calcDesiredPUFromCPU calculates the desired PU from a single CPU metric,

--- a/internal/controller/spannerautoscaler_controller_test.go
+++ b/internal/controller/spannerautoscaler_controller_test.go
@@ -435,6 +435,46 @@ var _ = Describe("Calculate Desired Processing Units (metric type switching guar
 		// scale down by at most scaledownStepSize=2000: max(1900, 5000-2000=3000) = 3000
 		Expect(calcDesiredProcessingUnits(sa)).To(Equal(3000))
 	})
+
+	// Total-only CPU scaling mode tests
+	It("total-only mode: keeps current PU until syncer populates Total status (guard)", func() {
+		sa := spannerv1beta1.SpannerAutoscaler{}
+		sa.Status.CurrentProcessingUnits = 3000
+		sa.Status.CurrentCPUMetricType = spannerv1beta1.CPUMetricTypeHighPriority // syncer hasn't run total-only yet
+		sa.Status.CurrentTotalCPUUtilization = 0
+		sa.Spec.ScaleConfig = baseScaleConfig()
+		sa.Spec.ScaleConfig.TargetCPUUtilization = spannerv1beta1.TargetCPUUtilization{
+			Total: intPtr(40),
+		}
+		Expect(calcDesiredProcessingUnits(sa)).To(Equal(3000))
+	})
+
+	It("total-only mode: scales up when total exceeds threshold", func() {
+		sa := spannerv1beta1.SpannerAutoscaler{}
+		sa.Status.CurrentProcessingUnits = 3000
+		sa.Status.CurrentCPUMetricType = spannerv1beta1.CPUMetricTypeTotal
+		sa.Status.CurrentTotalCPUUtilization = 60 // exceeds target 40
+		sa.Spec.ScaleConfig = baseScaleConfig()
+		sa.Spec.ScaleConfig.TargetCPUUtilization = spannerv1beta1.TargetCPUUtilization{
+			Total: intPtr(40),
+		}
+		// total: 60/40 * 3000 = 4500 → 5000
+		Expect(calcDesiredProcessingUnits(sa)).To(Equal(5000))
+	})
+
+	It("total-only mode: scales down when total is below threshold", func() {
+		sa := spannerv1beta1.SpannerAutoscaler{}
+		sa.Status.CurrentProcessingUnits = 5000
+		sa.Status.CurrentCPUMetricType = spannerv1beta1.CPUMetricTypeTotal
+		sa.Status.CurrentTotalCPUUtilization = 15 // below target 40
+		sa.Spec.ScaleConfig = baseScaleConfig()
+		sa.Spec.ScaleConfig.TargetCPUUtilization = spannerv1beta1.TargetCPUUtilization{
+			Total: intPtr(40),
+		}
+		// total: 15/40 * 5000 = 1875 → 1900
+		// scale down by at most scaledownStepSize=2000: max(1900, 5000-2000=3000) = 3000
+		Expect(calcDesiredProcessingUnits(sa)).To(Equal(3000))
+	})
 })
 
 var _ = Describe("Fetch Credentials", func() {

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -266,19 +266,27 @@ func (s *syncer) syncResource(ctx context.Context) error {
 		"spannerautoscaler", sa,
 	)
 
-	// Dual mode: both highPriority and total are specified.
-	isDual := sa.Spec.ScaleConfig.TargetCPUUtilization.Total != nil
+	metricFlags := sa.Spec.ScaleConfig.TargetCPUUtilization.ActiveMetricFlags()
 
 	var instance *spanner.Instance
 	var highPriorityMetrics, totalMetrics *metrics.InstanceMetrics
 	var err error
 
-	if isDual {
+	switch metricFlags {
+	case spannerv1beta1.CPUMetricFlagHighPriority | spannerv1beta1.CPUMetricFlagTotal:
 		instance, highPriorityMetrics, totalMetrics, err = s.getInstanceInfoDual(ctx)
-	} else {
+	case spannerv1beta1.CPUMetricFlagTotal:
+		var m *metrics.InstanceMetrics
+		instance, m, err = s.getInstanceInfo(ctx, metrics.MetricTypeTotal)
+		totalMetrics = m
+	case spannerv1beta1.CPUMetricFlagHighPriority:
 		var m *metrics.InstanceMetrics
 		instance, m, err = s.getInstanceInfo(ctx, metrics.MetricTypeHighPriority)
 		highPriorityMetrics = m
+	default:
+		// No metric configured — invalid spec that bypassed webhook validation. Skip sync.
+		log.Info("skipping sync: no CPU metric threshold configured")
+		return nil
 	}
 	if err != nil {
 		s.recorder.Eventf(&sa, corev1.EventTypeWarning, "FailedSpannerAPICall", "%s", err.Error())
@@ -289,7 +297,12 @@ func (s *syncer) syncResource(ctx context.Context) error {
 	log.V(1).Info("spanner instance status",
 		"current processing units", instance.ProcessingUnits,
 		"instance state", instance.InstanceState,
-		"high priority cpu utilization", highPriorityMetrics.CurrentHighPriorityCPUUtilization,
+		"high priority cpu utilization", func() int {
+			if highPriorityMetrics != nil {
+				return highPriorityMetrics.CurrentHighPriorityCPUUtilization
+			}
+			return 0
+		}(),
 		"total cpu utilization", func() int {
 			if totalMetrics != nil {
 				return totalMetrics.CurrentTotalCPUUtilization
@@ -307,11 +320,15 @@ func (s *syncer) syncResource(ctx context.Context) error {
 		// Zero both CPU fields first, then populate based on mode.
 		sa.Status.CurrentHighPriorityCPUUtilization = 0
 		sa.Status.CurrentTotalCPUUtilization = 0
-		if isDual {
+		switch metricFlags {
+		case spannerv1beta1.CPUMetricFlagHighPriority | spannerv1beta1.CPUMetricFlagTotal:
 			sa.Status.CurrentHighPriorityCPUUtilization = highPriorityMetrics.CurrentHighPriorityCPUUtilization
 			sa.Status.CurrentTotalCPUUtilization = totalMetrics.CurrentTotalCPUUtilization
 			sa.Status.CurrentCPUMetricType = spannerv1beta1.CPUMetricTypeBoth
-		} else {
+		case spannerv1beta1.CPUMetricFlagTotal:
+			sa.Status.CurrentTotalCPUUtilization = totalMetrics.CurrentTotalCPUUtilization
+			sa.Status.CurrentCPUMetricType = spannerv1beta1.CPUMetricTypeTotal
+		case spannerv1beta1.CPUMetricFlagHighPriority:
 			sa.Status.CurrentHighPriorityCPUUtilization = highPriorityMetrics.CurrentHighPriorityCPUUtilization
 			sa.Status.CurrentCPUMetricType = spannerv1beta1.CPUMetricTypeHighPriority
 		}

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -19,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	spannerv1alpha1 "github.com/mercari/spanner-autoscaler/api/v1alpha1"
 	spannerv1beta1 "github.com/mercari/spanner-autoscaler/api/v1beta1"
@@ -80,7 +82,12 @@ func TestController_E2E_ScaleUp(t *testing.T) {
 		t.Fatalf("add v1beta1 scheme: %v", err)
 	}
 
-	mgr, err := ctrl.NewManager(cfg, ctrl.Options{Scheme: k8sscheme.Scheme})
+	skipValidation := true
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:     k8sscheme.Scheme,
+		Metrics:    metricsserver.Options{BindAddress: "0"},
+		Controller: ctrlconfig.Controller{SkipNameValidation: &skipValidation},
+	})
 	if err != nil {
 		t.Fatalf("failed to create manager: %v", err)
 	}
@@ -167,4 +174,302 @@ func TestController_E2E_ScaleUp(t *testing.T) {
 	t.Errorf("controller did not scale up within timeout: PU=%d (want >%d), CPU=%d%%",
 		updated.Status.CurrentProcessingUnits, initPU,
 		updated.Status.CurrentHighPriorityCPUUtilization)
+}
+
+// TestController_E2E_ScaleUp_TotalOnly verifies the full scale-up flow using total-only mode:
+//
+//  1. A Spanner instance starts at 1000 PU in the Spanner emulator.
+//  2. A workload is configured using the 'total' metric only (no highPriority).
+//     At 1000 PU the total CPU utilization is 0.80 (80%), exceeding the target of 40%.
+//  3. The controller syncs the status (via the syncer) and decides to scale up.
+//  4. The test waits until the Spanner emulator instance PU increases.
+func TestController_E2E_ScaleUp_TotalOnly(t *testing.T) {
+	const (
+		projectID         = "e2e-total-project"
+		instanceID        = "e2e-total-instance"
+		initPU            = 1000
+		referenceCPU      = 0.80
+		syncInterval      = 3 * time.Second
+		scaleUpInterval   = 1 * time.Second
+		scaleDownInterval = 55 * time.Minute
+	)
+	targetCPUVal := 40
+	targetCPU := &targetCPUVal
+	skipValidation := true
+
+	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	// Configure dynamic (workload) mode using the total metric only.
+	// At 1000 PU with cpu=0.80: workload = 0.80 * 1000 = 800.
+	// After scale-up to e.g. 2000 PU: cpu = 800 / 2000 = 0.40 → at target.
+	body, _ := json.Marshal(map[string]interface{}{
+		"total": map[string]interface{}{
+			"cpu_utilization":            referenceCPU,
+			"reference_processing_units": initPU,
+		},
+	})
+	adminPUT(t, fmt.Sprintf("/workload/%s/%s", projectID, instanceID), body)
+	t.Cleanup(func() { adminDELETE(t, fmt.Sprintf("/workload/%s/%s", projectID, instanceID)) })
+
+	createSpannerInstance(t, projectID, instanceID, initPU)
+
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join(repoRoot(), "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+	cfg, err := testEnv.Start()
+	if err != nil {
+		t.Fatalf("failed to start envtest: %v", err)
+	}
+	t.Cleanup(func() { testEnv.Stop() }) //nolint:errcheck
+
+	if err := spannerv1alpha1.AddToScheme(k8sscheme.Scheme); err != nil {
+		t.Fatalf("add v1alpha1 scheme: %v", err)
+	}
+	if err := spannerv1beta1.AddToScheme(k8sscheme.Scheme); err != nil {
+		t.Fatalf("add v1beta1 scheme: %v", err)
+	}
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:     k8sscheme.Scheme,
+		Metrics:    metricsserver.Options{BindAddress: "0"},
+		Controller: ctrlconfig.Controller{SkipNameValidation: &skipValidation},
+	})
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	reconciler := controller.NewSpannerAutoscalerReconciler(
+		mgr.GetClient(),
+		mgr.GetAPIReader(),
+		mgr.GetScheme(),
+		mgr.GetEventRecorderFor("e2e-controller"),
+		logf.Log.WithName("e2e"),
+		controller.WithSpannerEndpoint(spannerEmulatorAddr()),
+		controller.WithMetricsEndpoint(monitoringGRPCAddr()),
+		controller.WithSyncInterval(syncInterval),
+		controller.WithScaleUpInterval(scaleUpInterval),
+		controller.WithScaleDownInterval(scaleDownInterval),
+	)
+	if err := reconciler.SetupWithManager(mgr); err != nil {
+		t.Fatalf("failed to setup controller: %v", err)
+	}
+
+	mgrCtx, mgrCancel := context.WithCancel(context.Background())
+	t.Cleanup(mgrCancel)
+	t.Cleanup(reconciler.StopAll)
+	go func() {
+		if err := mgr.Start(mgrCtx); err != nil {
+			t.Logf("manager exited: %v", err)
+		}
+	}()
+
+	k8sClient := mgr.GetClient()
+	ctx := context.Background()
+	nn := types.NamespacedName{Namespace: "default", Name: "e2e-total-sa"}
+
+	sa := &spannerv1beta1.SpannerAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nn.Name,
+			Namespace: nn.Namespace,
+		},
+		Spec: spannerv1beta1.SpannerAutoscalerSpec{
+			TargetInstance: spannerv1beta1.TargetInstance{
+				ProjectID:  projectID,
+				InstanceID: instanceID,
+			},
+			Authentication: spannerv1beta1.Authentication{
+				Type: spannerv1beta1.AuthTypeADC,
+			},
+			ScaleConfig: spannerv1beta1.ScaleConfig{
+				ComputeType: spannerv1beta1.ComputeTypePU,
+				ProcessingUnits: spannerv1beta1.ScaleConfigPUs{
+					Min: 100,
+					Max: 10000,
+				},
+				ScaledownStepSize: intstr.FromInt(2000),
+				ScaleupStepSize:   intstr.FromInt(1000),
+				TargetCPUUtilization: spannerv1beta1.TargetCPUUtilization{
+					Total: targetCPU,
+				},
+			},
+		},
+	}
+	if err := k8sClient.Create(ctx, sa); err != nil {
+		t.Fatalf("failed to create SpannerAutoscaler: %v", err)
+	}
+
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		var updated spannerv1beta1.SpannerAutoscaler
+		if err := k8sClient.Get(ctx, nn, &updated); err != nil {
+			time.Sleep(time.Second)
+			continue
+		}
+		if updated.Status.CurrentProcessingUnits > initPU {
+			t.Logf("scale-up succeeded: PU %d → %d (total CPU=%d%%)",
+				initPU, updated.Status.CurrentProcessingUnits,
+				updated.Status.CurrentTotalCPUUtilization)
+			return
+		}
+		time.Sleep(time.Second)
+	}
+
+	var updated spannerv1beta1.SpannerAutoscaler
+	k8sClient.Get(ctx, nn, &updated) //nolint:errcheck
+	t.Errorf("controller did not scale up within timeout: PU=%d (want >%d), total CPU=%d%%",
+		updated.Status.CurrentProcessingUnits, initPU,
+		updated.Status.CurrentTotalCPUUtilization)
+}
+
+// TestController_E2E_ScaleUp_Dual verifies the full scale-up flow using dual mode (OR condition):
+//
+//  1. A Spanner instance starts at 1000 PU in the Spanner emulator.
+//  2. Both high_priority and total workloads are configured. At 1000 PU, high_priority CPU is
+//     0.80 (80%), exceeding its 40% target; total CPU is 0.20 (20%), below its 30% target.
+//  3. Scale-out fires because high_priority exceeds its threshold (OR condition).
+//  4. The test waits until the Spanner emulator instance PU increases.
+func TestController_E2E_ScaleUp_Dual(t *testing.T) {
+	const (
+		projectID         = "e2e-dual-project"
+		instanceID        = "e2e-dual-instance"
+		initPU            = 1000
+		syncInterval      = 3 * time.Second
+		scaleUpInterval   = 1 * time.Second
+		scaleDownInterval = 55 * time.Minute
+	)
+	highPriorityCPUVal := 40
+	totalCPUVal := 30
+	skipValidation := true
+
+	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	// high_priority: 80% at 1000 PU → exceeds 40% target → triggers scale-up.
+	// total: 20% at 1000 PU → below 30% target → would not trigger alone.
+	// Dual mode (OR): scale-up happens because high_priority exceeds its threshold.
+	body, _ := json.Marshal(map[string]interface{}{
+		"high_priority": map[string]interface{}{
+			"cpu_utilization":            0.80,
+			"reference_processing_units": initPU,
+		},
+		"total": map[string]interface{}{
+			"cpu_utilization":            0.20,
+			"reference_processing_units": initPU,
+		},
+	})
+	adminPUT(t, fmt.Sprintf("/workload/%s/%s", projectID, instanceID), body)
+	t.Cleanup(func() { adminDELETE(t, fmt.Sprintf("/workload/%s/%s", projectID, instanceID)) })
+
+	createSpannerInstance(t, projectID, instanceID, initPU)
+
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join(repoRoot(), "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+	cfg, err := testEnv.Start()
+	if err != nil {
+		t.Fatalf("failed to start envtest: %v", err)
+	}
+	t.Cleanup(func() { testEnv.Stop() }) //nolint:errcheck
+
+	if err := spannerv1alpha1.AddToScheme(k8sscheme.Scheme); err != nil {
+		t.Fatalf("add v1alpha1 scheme: %v", err)
+	}
+	if err := spannerv1beta1.AddToScheme(k8sscheme.Scheme); err != nil {
+		t.Fatalf("add v1beta1 scheme: %v", err)
+	}
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:     k8sscheme.Scheme,
+		Metrics:    metricsserver.Options{BindAddress: "0"},
+		Controller: ctrlconfig.Controller{SkipNameValidation: &skipValidation},
+	})
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	reconciler := controller.NewSpannerAutoscalerReconciler(
+		mgr.GetClient(),
+		mgr.GetAPIReader(),
+		mgr.GetScheme(),
+		mgr.GetEventRecorderFor("e2e-controller"),
+		logf.Log.WithName("e2e"),
+		controller.WithSpannerEndpoint(spannerEmulatorAddr()),
+		controller.WithMetricsEndpoint(monitoringGRPCAddr()),
+		controller.WithSyncInterval(syncInterval),
+		controller.WithScaleUpInterval(scaleUpInterval),
+		controller.WithScaleDownInterval(scaleDownInterval),
+	)
+	if err := reconciler.SetupWithManager(mgr); err != nil {
+		t.Fatalf("failed to setup controller: %v", err)
+	}
+
+	mgrCtx, mgrCancel := context.WithCancel(context.Background())
+	t.Cleanup(mgrCancel)
+	t.Cleanup(reconciler.StopAll)
+	go func() {
+		if err := mgr.Start(mgrCtx); err != nil {
+			t.Logf("manager exited: %v", err)
+		}
+	}()
+
+	k8sClient := mgr.GetClient()
+	ctx := context.Background()
+	nn := types.NamespacedName{Namespace: "default", Name: "e2e-dual-sa"}
+
+	sa := &spannerv1beta1.SpannerAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nn.Name,
+			Namespace: nn.Namespace,
+		},
+		Spec: spannerv1beta1.SpannerAutoscalerSpec{
+			TargetInstance: spannerv1beta1.TargetInstance{
+				ProjectID:  projectID,
+				InstanceID: instanceID,
+			},
+			Authentication: spannerv1beta1.Authentication{
+				Type: spannerv1beta1.AuthTypeADC,
+			},
+			ScaleConfig: spannerv1beta1.ScaleConfig{
+				ComputeType: spannerv1beta1.ComputeTypePU,
+				ProcessingUnits: spannerv1beta1.ScaleConfigPUs{
+					Min: 100,
+					Max: 10000,
+				},
+				ScaledownStepSize: intstr.FromInt(2000),
+				ScaleupStepSize:   intstr.FromInt(1000),
+				TargetCPUUtilization: spannerv1beta1.TargetCPUUtilization{
+					HighPriority: &highPriorityCPUVal,
+					Total:        &totalCPUVal,
+				},
+			},
+		},
+	}
+	if err := k8sClient.Create(ctx, sa); err != nil {
+		t.Fatalf("failed to create SpannerAutoscaler: %v", err)
+	}
+
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		var updated spannerv1beta1.SpannerAutoscaler
+		if err := k8sClient.Get(ctx, nn, &updated); err != nil {
+			time.Sleep(time.Second)
+			continue
+		}
+		if updated.Status.CurrentProcessingUnits > initPU {
+			t.Logf("scale-up succeeded: PU %d → %d (highPriority CPU=%d%%, total CPU=%d%%)",
+				initPU, updated.Status.CurrentProcessingUnits,
+				updated.Status.CurrentHighPriorityCPUUtilization,
+				updated.Status.CurrentTotalCPUUtilization)
+			return
+		}
+		time.Sleep(time.Second)
+	}
+
+	var updated spannerv1beta1.SpannerAutoscaler
+	k8sClient.Get(ctx, nn, &updated) //nolint:errcheck
+	t.Errorf("controller did not scale up within timeout: PU=%d (want >%d), highPriority CPU=%d%%, total CPU=%d%%",
+		updated.Status.CurrentProcessingUnits, initPU,
+		updated.Status.CurrentHighPriorityCPUUtilization,
+		updated.Status.CurrentTotalCPUUtilization)
 }

--- a/test/integration/syncer_test.go
+++ b/test/integration/syncer_test.go
@@ -120,3 +120,210 @@ func TestSyncer_SyncResource(t *testing.T) {
 		updated.Status.CurrentHighPriorityCPUUtilization, wantCPU,
 	)
 }
+
+func TestSyncer_SyncResource_TotalOnly(t *testing.T) {
+	const (
+		projectID  = "syncer-total-project"
+		instanceID = "syncer-total-instance"
+		initPU     = 1000
+		wantCPU    = 60 // 0.60 * 100
+	)
+
+	// Configure static total CPU utilization in the monitoring emulator (no high_priority).
+	body, _ := json.Marshal(map[string]float64{"total": 0.60})
+	adminPUT(t, fmt.Sprintf("/metrics/%s/%s", projectID, instanceID), body)
+	t.Cleanup(func() { adminDELETE(t, fmt.Sprintf("/metrics/%s/%s", projectID, instanceID)) })
+
+	createSpannerInstance(t, projectID, instanceID, initPU)
+
+	k8sClient := startEnvtest(t)
+
+	ctx := context.Background()
+	nn := types.NamespacedName{Namespace: "default", Name: "syncer-total-sa"}
+
+	totalCPUVal := 40
+	sa := &spannerv1beta1.SpannerAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nn.Name,
+			Namespace: nn.Namespace,
+		},
+		Spec: spannerv1beta1.SpannerAutoscalerSpec{
+			TargetInstance: spannerv1beta1.TargetInstance{
+				ProjectID:  projectID,
+				InstanceID: instanceID,
+			},
+			Authentication: spannerv1beta1.Authentication{
+				Type: spannerv1beta1.AuthTypeADC,
+			},
+			ScaleConfig: spannerv1beta1.ScaleConfig{
+				ComputeType: spannerv1beta1.ComputeTypePU,
+				ProcessingUnits: spannerv1beta1.ScaleConfigPUs{
+					Min: 100,
+					Max: 10000,
+				},
+				ScaledownStepSize: intstr.FromInt(2000),
+				TargetCPUUtilization: spannerv1beta1.TargetCPUUtilization{
+					Total: &totalCPUVal,
+				},
+			},
+		},
+	}
+	if err := k8sClient.Create(ctx, sa); err != nil {
+		t.Fatalf("failed to create SpannerAutoscaler: %v", err)
+	}
+
+	spannerClient, err := spanner.NewClient(ctx, projectID, instanceID,
+		spanner.WithEndpoint(spannerEmulatorAddr()),
+	)
+	if err != nil {
+		t.Fatalf("failed to create spanner client: %v", err)
+	}
+
+	metricsClient, err := metrics.NewClient(ctx, projectID, instanceID,
+		metrics.WithEndpoint(monitoringGRPCAddr()),
+	)
+	if err != nil {
+		t.Fatalf("failed to create metrics client: %v", err)
+	}
+
+	creds := syncer.NewADCCredentials()
+	recorder := record.NewFakeRecorder(100)
+	s, err := syncer.New(ctx, k8sClient, nn, creds, recorder, spannerClient, metricsClient,
+		syncer.WithInterval(2*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("failed to create syncer: %v", err)
+	}
+
+	go s.Start()
+	t.Cleanup(s.Stop)
+
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		var updated spannerv1beta1.SpannerAutoscaler
+		if err := k8sClient.Get(ctx, nn, &updated); err != nil {
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+		if updated.Status.CurrentProcessingUnits == initPU &&
+			updated.Status.CurrentTotalCPUUtilization == wantCPU &&
+			updated.Status.CurrentCPUMetricType == spannerv1beta1.CPUMetricTypeTotal {
+			return // success
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	var updated spannerv1beta1.SpannerAutoscaler
+	k8sClient.Get(ctx, nn, &updated) //nolint:errcheck
+	t.Errorf("syncer did not update status within timeout: PU=%d (want %d), total CPU=%d (want %d), metric type=%s (want %s)",
+		updated.Status.CurrentProcessingUnits, initPU,
+		updated.Status.CurrentTotalCPUUtilization, wantCPU,
+		updated.Status.CurrentCPUMetricType, spannerv1beta1.CPUMetricTypeTotal,
+	)
+}
+
+func TestSyncer_SyncResource_Dual(t *testing.T) {
+	const (
+		projectID        = "syncer-dual-project"
+		instanceID       = "syncer-dual-instance"
+		initPU           = 1000
+		wantHighPriority = 60 // 0.60 * 100
+		wantTotal        = 45 // 0.45 * 100
+	)
+
+	// Configure both high_priority and total static metrics.
+	body, _ := json.Marshal(map[string]float64{"high_priority": 0.60, "total": 0.45})
+	adminPUT(t, fmt.Sprintf("/metrics/%s/%s", projectID, instanceID), body)
+	t.Cleanup(func() { adminDELETE(t, fmt.Sprintf("/metrics/%s/%s", projectID, instanceID)) })
+
+	createSpannerInstance(t, projectID, instanceID, initPU)
+
+	k8sClient := startEnvtest(t)
+
+	ctx := context.Background()
+	nn := types.NamespacedName{Namespace: "default", Name: "syncer-dual-sa"}
+
+	highPriorityCPUVal := 40
+	totalCPUVal := 30
+	sa := &spannerv1beta1.SpannerAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nn.Name,
+			Namespace: nn.Namespace,
+		},
+		Spec: spannerv1beta1.SpannerAutoscalerSpec{
+			TargetInstance: spannerv1beta1.TargetInstance{
+				ProjectID:  projectID,
+				InstanceID: instanceID,
+			},
+			Authentication: spannerv1beta1.Authentication{
+				Type: spannerv1beta1.AuthTypeADC,
+			},
+			ScaleConfig: spannerv1beta1.ScaleConfig{
+				ComputeType: spannerv1beta1.ComputeTypePU,
+				ProcessingUnits: spannerv1beta1.ScaleConfigPUs{
+					Min: 100,
+					Max: 10000,
+				},
+				ScaledownStepSize: intstr.FromInt(2000),
+				TargetCPUUtilization: spannerv1beta1.TargetCPUUtilization{
+					HighPriority: &highPriorityCPUVal,
+					Total:        &totalCPUVal,
+				},
+			},
+		},
+	}
+	if err := k8sClient.Create(ctx, sa); err != nil {
+		t.Fatalf("failed to create SpannerAutoscaler: %v", err)
+	}
+
+	spannerClient, err := spanner.NewClient(ctx, projectID, instanceID,
+		spanner.WithEndpoint(spannerEmulatorAddr()),
+	)
+	if err != nil {
+		t.Fatalf("failed to create spanner client: %v", err)
+	}
+
+	metricsClient, err := metrics.NewClient(ctx, projectID, instanceID,
+		metrics.WithEndpoint(monitoringGRPCAddr()),
+	)
+	if err != nil {
+		t.Fatalf("failed to create metrics client: %v", err)
+	}
+
+	creds := syncer.NewADCCredentials()
+	recorder := record.NewFakeRecorder(100)
+	s, err := syncer.New(ctx, k8sClient, nn, creds, recorder, spannerClient, metricsClient,
+		syncer.WithInterval(2*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("failed to create syncer: %v", err)
+	}
+
+	go s.Start()
+	t.Cleanup(s.Stop)
+
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		var updated spannerv1beta1.SpannerAutoscaler
+		if err := k8sClient.Get(ctx, nn, &updated); err != nil {
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+		if updated.Status.CurrentProcessingUnits == initPU &&
+			updated.Status.CurrentHighPriorityCPUUtilization == wantHighPriority &&
+			updated.Status.CurrentTotalCPUUtilization == wantTotal &&
+			updated.Status.CurrentCPUMetricType == spannerv1beta1.CPUMetricTypeBoth {
+			return // success
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	var updated spannerv1beta1.SpannerAutoscaler
+	k8sClient.Get(ctx, nn, &updated) //nolint:errcheck
+	t.Errorf("syncer did not update status within timeout: PU=%d (want %d), highPriority CPU=%d (want %d), total CPU=%d (want %d), metric type=%s (want %s)",
+		updated.Status.CurrentProcessingUnits, initPU,
+		updated.Status.CurrentHighPriorityCPUUtilization, wantHighPriority,
+		updated.Status.CurrentTotalCPUUtilization, wantTotal,
+		updated.Status.CurrentCPUMetricType, spannerv1beta1.CPUMetricTypeBoth,
+	)
+}


### PR DESCRIPTION
## Summary

Make `highPriority` optional in `TargetCPUUtilization` so that `total`-only mode can be configured without specifying `highPriority`.

## Supported modes after this change

| highPriority | total | Mode |
|---|---|---|
| ✓ | — | highPriority-only (existing) |
| — | ✓ | **total-only (new)** |
| ✓ | ✓ | dual / both (existing, OR condition) |
| — | — | validation error |

## Changes

### API / CRD
- `TargetCPUUtilization.HighPriority`: added `omitempty`, updated comment from "Required" to "Optional"
- CRD schema: removed `required: - highPriority` from v1beta1
- Webhook validation: "at least one of 'highPriority' or 'total' must be specified"

### Internal refactoring
Replaced boolean variables (`isDual`, `isTotalOnly`) with a `CPUMetricFlags` bitmask type and `switch` statement on `TargetCPUUtilization.ActiveMetricFlags()`.

```go
type CPUMetricFlags uint8
const (
    CPUMetricFlagHighPriority CPUMetricFlags = 1 << iota  // 0b01
    CPUMetricFlagTotal                                      // 0b10
)
```

Adding a new metric in the future only requires: 1 constant + 1 line in `ActiveMetricFlags()` + new `case` in each switch.

## Tests

### Unit tests
- Updated webhook tests (total-only → success, neither → new error message)
- Added 3 unit tests for total-only mode in controller

### Integration tests (emulator)
All 8 integration tests pass:
- `TestSyncer_SyncResource` (highPriority-only, existing)
- `TestSyncer_SyncResource_TotalOnly` (new)
- `TestSyncer_SyncResource_Dual` (new — verifies dual mode after refactoring)
- `TestController_E2E_ScaleUp` (highPriority-only, existing)
- `TestController_E2E_ScaleUp_TotalOnly` (new)
- `TestController_E2E_ScaleUp_Dual` (new — verifies OR condition still works)
- `TestMetricsClient_GetInstanceMetrics_Static`
- `TestMetricsClient_GetInstanceMetrics_NotFound`

🤖 Generated with [Claude Code](https://claude.com/claude-code)