### PR TITLE
Improve CPU metric observability: clearer log keys and dual-mode time alignment

### DIFF
--- a/api/v1beta1/spannerautoscaler_types.go
+++ b/api/v1beta1/spannerautoscaler_types.go
@@ -307,11 +307,20 @@ type SpannerAutoscalerStatus struct {
 	// State of the Cloud Spanner instance
 	InstanceState InstanceState `json:"instanceState,omitempty"`
 
-	// Current average CPU utilization for high priority task, represented as a percentage
+	// Current average CPU utilization for high priority task, represented as a percentage.
+	// In dual CPU scaling mode (both highPriority and total configured), this value is
+	// fetched concurrently with currentTotalCPUUtilization. Because Cloud Monitoring
+	// ingests the underlying metrics (utilization_by_priority and utilization) independently,
+	// the two fields may briefly reflect different alignment windows and the relation
+	// currentTotalCPUUtilization >= currentHighPriorityCPUUtilization is not guaranteed
+	// on every sync. The autoscaling decision uses both values independently and takes
+	// the larger required processing units, so the transient inconsistency does not cause
+	// over-scaling down.
 	CurrentHighPriorityCPUUtilization int `json:"currentHighPriorityCPUUtilization,omitempty"`
 
 	// Current total CPU utilization (all priorities), represented as a percentage.
 	// This field is populated only when spec.scaleConfig.targetCPUUtilization.total is specified.
+	// See the note on currentHighPriorityCPUUtilization for the consistency caveat in dual mode.
 	CurrentTotalCPUUtilization int `json:"currentTotalCPUUtilization,omitempty"`
 
 	// CurrentCPUMetricType is the CPU metric type that was used in the last sync cycle.

--- a/api/v1beta1/spannerautoscaler_types.go
+++ b/api/v1beta1/spannerautoscaler_types.go
@@ -223,6 +223,21 @@ func (c TargetCPUUtilization) ActiveMetricFlags() CPUMetricFlags {
 	return f
 }
 
+// ToCPUMetricType maps the flag bitmask to the corresponding CPUMetricType.
+// Returns an empty CPUMetricType when no flag is set.
+func (f CPUMetricFlags) ToCPUMetricType() CPUMetricType {
+	switch f {
+	case CPUMetricFlagHighPriority | CPUMetricFlagTotal:
+		return CPUMetricTypeBoth
+	case CPUMetricFlagTotal:
+		return CPUMetricTypeTotal
+	case CPUMetricFlagHighPriority:
+		return CPUMetricTypeHighPriority
+	default:
+		return ""
+	}
+}
+
 // SpannerAutoscalerSpec defines the desired state of SpannerAutoscaler
 type SpannerAutoscalerSpec struct {
 	// The Spanner instance which will be managed for autoscaling

--- a/docs/crd-reference.md
+++ b/docs/crd-reference.md
@@ -347,8 +347,8 @@ _Appears in:_
 | `desiredMinPUs` _integer_ | Minimum number of processing units based on the currently active schedules |  |  |
 | `desiredMaxPUs` _integer_ | Maximum number of processing units based on the currently active schedules |  |  |
 | `instanceState` _[InstanceState](#instancestate)_ | State of the Cloud Spanner instance |  |  |
-| `currentHighPriorityCPUUtilization` _integer_ | Current average CPU utilization for high priority task, represented as a percentage |  |  |
-| `currentTotalCPUUtilization` _integer_ | Current total CPU utilization (all priorities), represented as a percentage.<br />This field is populated only when spec.scaleConfig.targetCPUUtilization.total is specified. |  |  |
+| `currentHighPriorityCPUUtilization` _integer_ | Current average CPU utilization for high priority task, represented as a percentage.<br />In dual CPU scaling mode (both highPriority and total configured), this value is<br />fetched concurrently with currentTotalCPUUtilization. Because Cloud Monitoring<br />ingests the underlying metrics (utilization_by_priority and utilization) independently,<br />the two fields may briefly reflect different alignment windows and the relation<br />currentTotalCPUUtilization >= currentHighPriorityCPUUtilization is not guaranteed<br />on every sync. The autoscaling decision uses both values independently and takes<br />the larger required processing units, so the transient inconsistency does not cause<br />over-scaling down. |  |  |
+| `currentTotalCPUUtilization` _integer_ | Current total CPU utilization (all priorities), represented as a percentage.<br />This field is populated only when spec.scaleConfig.targetCPUUtilization.total is specified.<br />See the note on currentHighPriorityCPUUtilization for the consistency caveat in dual mode. |  |  |
 | `currentCPUMetricType` _[CPUMetricType](#cpumetrictype)_ | CurrentCPUMetricType is the CPU metric type that was used in the last sync cycle.<br />The controller uses this to detect metric-type switches and skip scaling until<br />the status reflects the newly configured metric type. |  | Enum: [HighPriority Total Both] <br /> |
 
 

--- a/internal/controller/spannerautoscaler_controller.go
+++ b/internal/controller/spannerautoscaler_controller.go
@@ -621,7 +621,12 @@ func (r *SpannerAutoscalerReconciler) needUpdateProcessingUnits(log logr.Logger,
 
 	switch {
 	case desiredProcessingUnits == currentProcessingUnits:
-		log.Info("no need to scale", "currentPU", currentProcessingUnits, "currentCPU", sa.Status.CurrentHighPriorityCPUUtilization)
+		log.Info("no need to scale",
+			"currentPU", currentProcessingUnits,
+			"currentCPUMetricType", sa.Status.CurrentCPUMetricType,
+			"currentHighPriorityCPUUtilization", sa.Status.CurrentHighPriorityCPUUtilization,
+			"currentTotalCPUUtilization", sa.Status.CurrentTotalCPUUtilization,
+		)
 		return false
 
 	case currentProcessingUnits < desiredProcessingUnits && r.clock.Now().Before(sa.Status.LastScaleTime.Time.Add(getOrConvertTimeDuration(sa.Spec.ScaleConfig.ScaleupInterval, r.scaleUpInterval))):

--- a/internal/metrics/fake.go
+++ b/internal/metrics/fake.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"context"
 	"sync"
+	"time"
 )
 
 // FakeClient implements Client but operates fake objects for testing.
@@ -27,8 +28,9 @@ func NewFakeClient(metrics *InstanceMetrics) *FakeClient {
 // GetInstanceMetrics implements Client.
 // It returns a copy of the stored metrics with only the field corresponding to
 // metricType populated, mirroring the real client's behavior and preventing the
-// other field from masking bugs caused by stale values.
-func (c *FakeClient) GetInstanceMetrics(ctx context.Context, metricType MetricType) (*InstanceMetrics, error) {
+// other field from masking bugs caused by stale values. The now argument is
+// accepted to satisfy the Client interface and is otherwise ignored.
+func (c *FakeClient) GetInstanceMetrics(ctx context.Context, metricType MetricType, _ time.Time) (*InstanceMetrics, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	switch metricType {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -16,7 +16,6 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	utilclock "k8s.io/utils/clock"
 )
 
 // MetricType represents which Cloud Monitoring metric to query.
@@ -51,7 +50,12 @@ type InstanceMetrics struct {
 // Client is a client for manipulation of InstanceMetrics.
 type Client interface {
 	// GetInstanceMetrics gets the instance metrics for the given metric type.
-	GetInstanceMetrics(ctx context.Context, metricType MetricType) (*InstanceMetrics, error)
+	// The now parameter is the reference time for the query window
+	// (StartTime = now - term, EndTime = now). Callers that issue several
+	// GetInstanceMetrics calls whose results need to align should pass the
+	// same now to each call so the underlying Cloud Monitoring queries hit
+	// the same alignment window.
+	GetInstanceMetrics(ctx context.Context, metricType MetricType, now time.Time) (*InstanceMetrics, error)
 }
 
 // client is a client for Stackdriver Monitoring.
@@ -65,8 +69,7 @@ type client struct {
 	endpoint    string
 	tokenSource oauth2.TokenSource
 
-	clock utilclock.Clock
-	log   logr.Logger
+	log logr.Logger
 }
 
 var _ Client = (*client)(nil)
@@ -91,12 +94,6 @@ func WithTokenSource(ts oauth2.TokenSource) Option {
 	}
 }
 
-func WithClock(clock utilclock.Clock) Option {
-	return func(c *client) {
-		c.clock = clock
-	}
-}
-
 func WithLog(log logr.Logger) Option {
 	return func(c *client) {
 		c.log = log.WithName("metrics")
@@ -109,7 +106,6 @@ func NewClient(ctx context.Context, projectID, instanceID string, opts ...Option
 		projectID:  projectID,
 		instanceID: instanceID,
 		term:       10 * time.Minute,
-		clock:      utilclock.RealClock{},
 		log:        logr.Discard(),
 	}
 
@@ -141,7 +137,7 @@ func NewClient(ctx context.Context, projectID, instanceID string, opts ...Option
 
 // GetInstanceMetrics implements Client.
 // https://cloud.google.com/monitoring/custom-metrics/reading-metrics#monitoring_read_timeseries_fields-go
-func (c *client) GetInstanceMetrics(ctx context.Context, metricType MetricType) (*InstanceMetrics, error) {
+func (c *client) GetInstanceMetrics(ctx context.Context, metricType MetricType, now time.Time) (*InstanceMetrics, error) {
 	log := c.log.WithValues("instance-id", c.instanceID, "project-id", c.projectID)
 
 	log.V(1).Info("getting monitoring time series data")
@@ -154,15 +150,16 @@ func (c *client) GetInstanceMetrics(ctx context.Context, metricType MetricType) 
 		filter = fmt.Sprintf(metricsFilterFormatHighPriority, c.instanceID)
 	}
 
+	nowUTC := now.UTC()
 	req := &monitoringpb.ListTimeSeriesRequest{
 		Name:   fmt.Sprintf("projects/%s", c.projectID),
 		Filter: filter,
 		Interval: &monitoringpb.TimeInterval{
 			StartTime: &timestamp.Timestamp{
-				Seconds: c.clock.Now().UTC().Add(-c.term).Unix(),
+				Seconds: nowUTC.Add(-c.term).Unix(),
 			},
 			EndTime: &timestamp.Timestamp{
-				Seconds: c.clock.Now().UTC().Unix(),
+				Seconds: nowUTC.Unix(),
 			},
 		},
 		Aggregation: &monitoringpb.Aggregation{

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -295,15 +295,16 @@ func (s *syncer) syncResource(ctx context.Context) error {
 	}
 
 	log.V(1).Info("spanner instance status",
-		"current processing units", instance.ProcessingUnits,
-		"instance state", instance.InstanceState,
-		"high priority cpu utilization", func() int {
+		"currentProcessingUnits", instance.ProcessingUnits,
+		"instanceState", instance.InstanceState,
+		"currentCPUMetricType", metricFlags.ToCPUMetricType(),
+		"currentHighPriorityCPUUtilization", func() int {
 			if highPriorityMetrics != nil {
 				return highPriorityMetrics.CurrentHighPriorityCPUUtilization
 			}
 			return 0
 		}(),
-		"total cpu utilization", func() int {
+		"currentTotalCPUUtilization", func() int {
 			if totalMetrics != nil {
 				return totalMetrics.CurrentTotalCPUUtilization
 			}
@@ -349,6 +350,18 @@ func (s *syncer) syncResource(ctx context.Context) error {
 	return nil
 }
 
+// metricsTypeToCPUMetricType maps a metrics package MetricType to the
+// corresponding v1beta1 CPUMetricType. Keeping this mapping in syncer avoids
+// a cross-package import between metrics and v1beta1.
+func metricsTypeToCPUMetricType(t metrics.MetricType) spannerv1beta1.CPUMetricType {
+	switch t {
+	case metrics.MetricTypeTotal:
+		return spannerv1beta1.CPUMetricTypeTotal
+	default: // metrics.MetricTypeHighPriority
+		return spannerv1beta1.CPUMetricTypeHighPriority
+	}
+}
+
 func (s *syncer) getInstanceInfo(ctx context.Context, metricType metrics.MetricType) (*spanner.Instance, *metrics.InstanceMetrics, error) {
 	log := s.log
 	eg, ctx := errgroup.WithContext(ctx)
@@ -366,8 +379,8 @@ func (s *syncer) getInstanceInfo(ctx context.Context, metricType metrics.MetricT
 			return err
 		}
 		log.V(1).Info("successfully got spanner instance with spanner client",
-			"current processing units", instance.ProcessingUnits,
-			"instance state", instance.InstanceState,
+			"currentProcessingUnits", instance.ProcessingUnits,
+			"instanceState", instance.InstanceState,
 		)
 		return nil
 	})
@@ -380,8 +393,9 @@ func (s *syncer) getInstanceInfo(ctx context.Context, metricType metrics.MetricT
 			return err
 		}
 		log.V(1).Info("successfully got spanner instance metrics with metrics client",
-			"high priority cpu utilization", instanceMetrics.CurrentHighPriorityCPUUtilization,
-			"total cpu utilization", instanceMetrics.CurrentTotalCPUUtilization,
+			"currentCPUMetricType", metricsTypeToCPUMetricType(metricType),
+			"currentHighPriorityCPUUtilization", instanceMetrics.CurrentHighPriorityCPUUtilization,
+			"currentTotalCPUUtilization", instanceMetrics.CurrentTotalCPUUtilization,
 		)
 		return nil
 	})
@@ -414,8 +428,8 @@ func (s *syncer) getInstanceInfoDual(ctx context.Context) (*spanner.Instance, *m
 			return err
 		}
 		log.V(1).Info("successfully got spanner instance with spanner client",
-			"current processing units", instance.ProcessingUnits,
-			"instance state", instance.InstanceState,
+			"currentProcessingUnits", instance.ProcessingUnits,
+			"instanceState", instance.InstanceState,
 		)
 		return nil
 	})
@@ -428,7 +442,7 @@ func (s *syncer) getInstanceInfoDual(ctx context.Context) (*spanner.Instance, *m
 			return err
 		}
 		log.V(1).Info("successfully got high priority cpu metrics",
-			"high priority cpu utilization", highPriorityMetrics.CurrentHighPriorityCPUUtilization,
+			"currentHighPriorityCPUUtilization", highPriorityMetrics.CurrentHighPriorityCPUUtilization,
 		)
 		return nil
 	})
@@ -441,7 +455,7 @@ func (s *syncer) getInstanceInfoDual(ctx context.Context) (*spanner.Instance, *m
 			return err
 		}
 		log.V(1).Info("successfully got total cpu metrics",
-			"total cpu utilization", totalMetrics.CurrentTotalCPUUtilization,
+			"currentTotalCPUUtilization", totalMetrics.CurrentTotalCPUUtilization,
 		)
 		return nil
 	})

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -366,6 +366,10 @@ func (s *syncer) getInstanceInfo(ctx context.Context, metricType metrics.MetricT
 	log := s.log
 	eg, ctx := errgroup.WithContext(ctx)
 
+	// Capture the base time once so the metrics query window is deterministic
+	// even if the goroutine starts a few milliseconds later.
+	now := s.clock.Now()
+
 	var (
 		instance        *spanner.Instance
 		instanceMetrics *metrics.InstanceMetrics
@@ -387,7 +391,7 @@ func (s *syncer) getInstanceInfo(ctx context.Context, metricType metrics.MetricT
 
 	eg.Go(func() error {
 		var err error
-		instanceMetrics, err = s.metricsClient.GetInstanceMetrics(ctx, metricType)
+		instanceMetrics, err = s.metricsClient.GetInstanceMetrics(ctx, metricType, now)
 		if err != nil {
 			log.Error(err, "unable to get spanner instance metrics with client")
 			return err
@@ -414,6 +418,12 @@ func (s *syncer) getInstanceInfoDual(ctx context.Context) (*spanner.Instance, *m
 	log := s.log
 	eg, ctx := errgroup.WithContext(ctx)
 
+	// Share a single base time between the two metric queries so they always
+	// target the same 60s alignment window. Without this, two independent
+	// clock reads can land on different sides of a minute boundary and cause
+	// the two CPU values to come from different aligned points.
+	now := s.clock.Now()
+
 	var (
 		instance            *spanner.Instance
 		highPriorityMetrics *metrics.InstanceMetrics
@@ -436,7 +446,7 @@ func (s *syncer) getInstanceInfoDual(ctx context.Context) (*spanner.Instance, *m
 
 	eg.Go(func() error {
 		var err error
-		highPriorityMetrics, err = s.metricsClient.GetInstanceMetrics(ctx, metrics.MetricTypeHighPriority)
+		highPriorityMetrics, err = s.metricsClient.GetInstanceMetrics(ctx, metrics.MetricTypeHighPriority, now)
 		if err != nil {
 			log.Error(err, "unable to get high priority cpu metrics")
 			return err
@@ -449,7 +459,7 @@ func (s *syncer) getInstanceInfoDual(ctx context.Context) (*spanner.Instance, *m
 
 	eg.Go(func() error {
 		var err error
-		totalMetrics, err = s.metricsClient.GetInstanceMetrics(ctx, metrics.MetricTypeTotal)
+		totalMetrics, err = s.metricsClient.GetInstanceMetrics(ctx, metrics.MetricTypeTotal, now)
 		if err != nil {
 			log.Error(err, "unable to get total cpu metrics")
 			return err

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -3,6 +3,7 @@ package syncer
 import (
 	"context"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -222,6 +223,7 @@ func Test_syncer_getInstanceInfo(t *testing.T) {
 					l := zap.NewAtomicLevelAt(zap.DebugLevel)
 					return ctrlzap.New(ctrlzap.Level(&l))
 				}(),
+				clock: testingclock.NewFakeClock(time.Date(2020, 4, 1, 0, 0, 0, 0, time.Local)),
 			}
 
 			ctx := context.Background()
@@ -241,3 +243,59 @@ func Test_syncer_getInstanceInfo(t *testing.T) {
 }
 
 func intPtr(i int) *int { return &i }
+
+// recordingMetricsClient is a metrics.Client that records the now value each
+// GetInstanceMetrics call received, keyed by MetricType. Used to verify that
+// dual-mode metric queries share a single base time.
+type recordingMetricsClient struct {
+	mu    sync.Mutex
+	calls map[metrics.MetricType]time.Time
+}
+
+func (c *recordingMetricsClient) GetInstanceMetrics(_ context.Context, metricType metrics.MetricType, now time.Time) (*metrics.InstanceMetrics, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.calls == nil {
+		c.calls = map[metrics.MetricType]time.Time{}
+	}
+	c.calls[metricType] = now
+	switch metricType {
+	case metrics.MetricTypeTotal:
+		return &metrics.InstanceMetrics{CurrentTotalCPUUtilization: 10}, nil
+	default:
+		return &metrics.InstanceMetrics{CurrentHighPriorityCPUUtilization: 20}, nil
+	}
+}
+
+func Test_syncer_getInstanceInfoDual_sharesBaseTime(t *testing.T) {
+	rec := &recordingMetricsClient{}
+	fakeTime := time.Date(2020, 4, 1, 12, 34, 56, 0, time.UTC)
+	s := &syncer{
+		spannerClient: spanner.NewFakeClient(&spanner.Instance{
+			ProcessingUnits: 1000,
+			InstanceState:   spanner.StateReady,
+		}),
+		metricsClient: rec,
+		log: func() logr.Logger {
+			l := zap.NewAtomicLevelAt(zap.DebugLevel)
+			return ctrlzap.New(ctrlzap.Level(&l))
+		}(),
+		clock: testingclock.NewFakeClock(fakeTime),
+	}
+
+	if _, _, _, err := s.getInstanceInfoDual(context.Background()); err != nil {
+		t.Fatalf("getInstanceInfoDual() error: %v", err)
+	}
+
+	hp, okHP := rec.calls[metrics.MetricTypeHighPriority]
+	tot, okTotal := rec.calls[metrics.MetricTypeTotal]
+	if !okHP || !okTotal {
+		t.Fatalf("expected both metric types to be queried, got calls=%v", rec.calls)
+	}
+	if !hp.Equal(tot) {
+		t.Errorf("dual-mode calls received different now values: highPriority=%s total=%s", hp, tot)
+	}
+	if !hp.Equal(fakeTime) {
+		t.Errorf("now passed to GetInstanceMetrics = %s, want %s", hp, fakeTime)
+	}
+}

--- a/test/integration/metrics_test.go
+++ b/test/integration/metrics_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/mercari/spanner-autoscaler/internal/metrics"
 )
@@ -30,7 +31,7 @@ func TestMetricsClient_GetInstanceMetrics_Static(t *testing.T) {
 		t.Fatalf("failed to create metrics client: %v", err)
 	}
 
-	got, err := c.GetInstanceMetrics(ctx, metrics.MetricTypeHighPriority)
+	got, err := c.GetInstanceMetrics(ctx, metrics.MetricTypeHighPriority, time.Now())
 	if err != nil {
 		t.Fatalf("GetInstanceMetrics() error: %v", err)
 	}
@@ -50,7 +51,7 @@ func TestMetricsClient_GetInstanceMetrics_NotFound(t *testing.T) {
 		t.Fatalf("failed to create metrics client: %v", err)
 	}
 
-	_, err = c.GetInstanceMetrics(ctx, metrics.MetricTypeHighPriority)
+	_, err = c.GetInstanceMetrics(ctx, metrics.MetricTypeHighPriority, time.Now())
 	if err == nil {
 		t.Fatal("GetInstanceMetrics() expected error for unconfigured instance, got nil")
 	}


### PR DESCRIPTION
## Summary

This branch contains two related improvements to CPU metric observability that surfaced during v0.8.0 dev verification.

- **Clearer log keys**: the controller's `currentCPU` log attribute was emitted regardless of which CPU metric (HighPriority / Total / Both) was actually driving the scaling decision, which became misleading once total-only and dual modes shipped in v0.8.0. All CPU-related log keys in the controller and syncer are renamed to match the CRD Status field names (`currentHighPriorityCPUUtilization`, `currentTotalCPUUtilization`, `currentCPUMetricType`), and `currentCPUMetricType` is always emitted alongside the values so a 0 in an unused slot is unambiguous.
- **Dual-mode time alignment**: in dual CPU scaling mode the syncer issues two concurrent `ListTimeSeries` calls. Each call previously read its own clock to build the query window, so when the two reads straddled a 60s alignment boundary the responses could come from different aligned points, producing the surprising display where `CURRENT CPU TOTAL` was briefly lower than `CURRENT CPU HIGH` in `kubectl get spannerautoscaler`. `GetInstanceMetrics` now takes the reference time as a parameter and the syncer captures it once before launching the goroutines so both queries target the same window. The Cloud Monitoring side may still ingest the two underlying metrics with slightly different latency, so the residual consistency caveat is documented on the v1beta1 Status fields and surfaced through the CRD reference. The autoscaling decision uses each value independently and takes the larger required PU, so the transient inconsistency does not cause over-scaling down.

The commits are kept logically separate:
1. `refactor: align CPU metric log keys with CRD Status field names` — log key rename only, no behavioral change.
2. `feat(metrics): share a single base time across dual-mode metric queries` — `GetInstanceMetrics` signature change, dead `clock` field / `WithClock` option removed from the metrics package, CRD godoc note added, `docs/crd-reference.md` regenerated via `make docs`.
3. `test(syncer): cover the shared base time in dual-mode metric queries` — fixes a nil-clock regression in `Test_syncer_getInstanceInfo` and adds `Test_syncer_getInstanceInfoDual_sharesBaseTime` to lock in the shared-`now` invariant.

## Test plan

- [x] `gofmt -l .` clean
- [x] `make docs` regenerated and committed
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` produces only the two pre-existing `nolintlint` warnings in `cmd/main.go` that also exist on master
- [x] `KUBEBUILDER_ASSETS=... go test -count=1 ./...` — all packages pass, including envtest-based suites in `internal/controller`, `internal/syncer`, `api/v1beta1`
- [x] New `Test_syncer_getInstanceInfoDual_sharesBaseTime` asserts that both `GetInstanceMetrics` calls receive an identical `now` derived from the syncer's clock
- [ ] Manual verification in the dev environment: confirm the renamed log keys appear in HighPriority / Total / Dual modes and that `CURRENT CPU TOTAL < CURRENT CPU HIGH` no longer reproduces around minute boundaries (residual cases attributable to Cloud Monitoring ingestion latency may still occur — see the godoc note)

🤖 Generated with [Claude Code](https://claude.com/claude-code)