### PR TITLE
Improve scheduled scaling log visibility

### DIFF
--- a/internal/controller/spannerautoscaler_controller.go
+++ b/internal/controller/spannerautoscaler_controller.go
@@ -416,6 +416,12 @@ func (r *SpannerAutoscalerReconciler) Reconcile(ctx context.Context, req ctrlrec
 		if p := sa.Spec.ScaleConfig.TargetCPUUtilization.Total; p != nil {
 			totalTarget = *p
 		}
+		activeScheduleNames := make([]string, 0, len(sa.Status.CurrentlyActiveSchedules))
+		var scheduleAdditionalPU int
+		for _, as := range sa.Status.CurrentlyActiveSchedules {
+			activeScheduleNames = append(activeScheduleNames, as.ScheduleName)
+			scheduleAdditionalPU += as.AdditionalPU
+		}
 		log.V(1).Info("processing units need to be changed",
 			"currentPU", sa.Status.CurrentProcessingUnits,
 			"desiredPU", desiredProcessingUnits,
@@ -424,6 +430,8 @@ func (r *SpannerAutoscalerReconciler) Reconcile(ctx context.Context, req ctrlrec
 			"currentTotalCPUUtilization", sa.Status.CurrentTotalCPUUtilization,
 			"highPriorityTarget", highPriorityTarget,
 			"totalTarget", totalTarget,
+			"activeSchedules", activeScheduleNames,
+			"scheduleAdditionalPU", scheduleAdditionalPU,
 		)
 
 		if err := syncer.UpdateInstance(ctx, desiredProcessingUnits); err != nil {
@@ -449,6 +457,8 @@ func (r *SpannerAutoscalerReconciler) Reconcile(ctx context.Context, req ctrlrec
 			"currentTotalCPUUtilization", sa.Status.CurrentTotalCPUUtilization,
 			"highPriorityTarget", highPriorityTarget,
 			"totalTarget", totalTarget,
+			"activeSchedules", activeScheduleNames,
+			"scheduleAdditionalPU", scheduleAdditionalPU,
 		)
 
 		statusChanged = true
@@ -564,7 +574,11 @@ func pruneActiveSchedules(log logr.Logger, sa spannerv1beta1.SpannerAutoscaler) 
 	changed := false
 	for _, as := range sa.Status.CurrentlyActiveSchedules {
 		if _, found := findInArray(sa.Status.Schedules, as.ScheduleName); !found {
-			log.V(1).Info("removed currently active schedule", "ActiveSchedule", as)
+			log.Info("removed currently active schedule",
+				"schedule", as.ScheduleName,
+				"additionalPU", as.AdditionalPU,
+				"endTime", as.EndTime.Time,
+			)
 			changed = true
 			continue
 		}

--- a/internal/controller/spannerautoscaler_controller.go
+++ b/internal/controller/spannerautoscaler_controller.go
@@ -416,6 +416,11 @@ func (r *SpannerAutoscalerReconciler) Reconcile(ctx context.Context, req ctrlrec
 		if p := sa.Spec.ScaleConfig.TargetCPUUtilization.Total; p != nil {
 			totalTarget = *p
 		}
+		// For logging only: summarize the schedules currently in effect.
+		// CurrentlyActiveSchedules contains only schedules whose cron has fired
+		// and whose EndTime has not yet passed (not every configured schedule).
+		// Overlapping active schedules stack additively — this mirrors how
+		// calcDesiredPURange folds AdditionalPU into the min/max PU range.
 		activeScheduleNames := make([]string, 0, len(sa.Status.CurrentlyActiveSchedules))
 		var scheduleAdditionalPU int
 		for _, as := range sa.Status.CurrentlyActiveSchedules {

--- a/internal/controller/spannerautoscaleschedule_controller.go
+++ b/internal/controller/spannerautoscaleschedule_controller.go
@@ -156,9 +156,8 @@ func (r *SpannerAutoscaleScheduleReconciler) Reconcile(ctx context.Context, req 
 		return ctrl.Result{}, nil
 	}
 
-	log.Info("registering schedule with spanner-autoscaler", "autoscaler", ctrlclient.ObjectKeyFromObject(&sa).String())
-
 	if _, ok := findInArray(sa.Status.Schedules, req.NamespacedName.String()); !ok {
+		log.Info("registering schedule with spanner-autoscaler", "autoscaler", ctrlclient.ObjectKeyFromObject(&sa).String())
 		err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 			if err := r.ctrlClient.Get(ctx, nnsa, &sa); err != nil {
 				return err

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -93,7 +93,7 @@ func (s scheduler) Update(ctx context.Context) error {
 		}
 		log.V(1).Info("cleanup expired schedules", "autoscaler schedules", autoscaler.Status.Schedules, "autoscaler active schedules", autoscaler.Status.CurrentlyActiveSchedules)
 
-		autoscaler.Status.CurrentlyActiveSchedules, statusChanged = cleanupActiveSchedules(autoscaler.Status.CurrentlyActiveSchedules)
+		autoscaler.Status.CurrentlyActiveSchedules, statusChanged = cleanupActiveSchedules(log, autoscaler.Status.CurrentlyActiveSchedules)
 
 		if statusChanged {
 			return s.ctrlClient.Status().Update(ctx, &autoscaler)
@@ -109,13 +109,18 @@ func (s scheduler) Update(ctx context.Context) error {
 	return nil
 }
 
-func cleanupActiveSchedules(activeSchedules []spannerv1beta1.ActiveSchedule) ([]spannerv1beta1.ActiveSchedule, bool) {
+func cleanupActiveSchedules(log logr.Logger, activeSchedules []spannerv1beta1.ActiveSchedule) ([]spannerv1beta1.ActiveSchedule, bool) {
 	changed := false
 	result := []spannerv1beta1.ActiveSchedule{}
 	now := metav1.Now()
 	for _, as := range activeSchedules {
 		if as.EndTime.Before(&now) {
 			changed = true
+			log.Info("scheduled scaling deactivated",
+				"schedule", as.ScheduleName,
+				"additionalPU", as.AdditionalPU,
+				"endTime", as.EndTime.Time,
+			)
 			continue
 		}
 		result = append(result, as)
@@ -135,6 +140,7 @@ func (j Job) Run() {
 	if err := j.CtrlClient.Get(ctx, j.ScheduleName, &sas); err != nil {
 		j.Log.Error(err, "failed to get spanner-autoscale-schedule")
 	}
+	var cas spannerv1beta1.ActiveSchedule
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		if err := j.CtrlClient.Get(ctx, j.AutoscalerName, &sa); err != nil {
 			j.Log.Error(err, "failed to get spanner-autoscaler")
@@ -151,7 +157,7 @@ func (j Job) Run() {
 				activeSchedules = append(activeSchedules, as)
 			}
 		}
-		cas := spannerv1beta1.ActiveSchedule{
+		cas = spannerv1beta1.ActiveSchedule{
 			ScheduleName: j.ScheduleName.String(),
 			AdditionalPU: sas.Spec.AdditionalProcessingUnits,
 			EndTime:      metav1.Time{Time: metav1.Now().Add(duration)},
@@ -167,6 +173,12 @@ func (j Job) Run() {
 		// May be conflict if max retries were hit, or may be something unrelated
 		// like permissions or a network error
 		j.Log.Error(err, "failed to update spanner-autoscaler status for CurrentlyActiveSchedules")
+	} else {
+		j.Log.Info("scheduled scaling activated",
+			"additionalPU", cas.AdditionalPU,
+			"endTime", cas.EndTime.Time,
+			"duration", sas.Spec.Schedule.Duration,
+		)
 	}
 	j.Log.V(1).Info("cron job is now over")
 }


### PR DESCRIPTION
## Summary

Scheduled scaling events were largely invisible at the default log level.

- `scheduler.Job.Run` emitted only `V(1)` logs when a cron fired and created an `ActiveSchedule`.
- `EndTime`-based expiry produced no log at all.
- The Info `updated processing units via google cloud api` line carried CPU-related fields but no schedule information, so operators could not tell whether a scale-up was CPU-driven or schedule-driven without inspecting `sa.Status.CurrentlyActiveSchedules` separately.

This PR surfaces the schedule lifecycle and its effect on PU updates at Info, and also cleans up a noisy reconcile-loop log on the schedule controller.

### Changes

- `scheduler.Job.Run` now logs `scheduled scaling activated` after the status update succeeds, with `additionalPU` / `endTime` / `duration`.
- `scheduler.cleanupActiveSchedules` takes a `logr.Logger` and emits `scheduled scaling deactivated` for each entry dropped by `EndTime` expiry.
- `pruneActiveSchedules` in the autoscaler reconciler promotes `removed currently active schedule` from `V(1)` to Info and uses consistent keys (`schedule` / `additionalPU` / `endTime`).
- The `V(1)` `processing units need to be changed` and Info `updated processing units via google cloud api` lines now carry `activeSchedules` and `scheduleAdditionalPU`, so a schedule-driven scale event is identifiable from a single log line.
- `spannerautoscaleschedule_controller`: move the `registering schedule with spanner-autoscaler` Info log inside the `!found` branch so it fires only when registration actually happens, not on every reconcile.

## Test plan

- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go build ./...` succeeds
- [x] `golangci-lint run ./...` — no new findings (pre-existing `nolint:staticcheck` warnings on `cmd/main.go` unchanged)
- [ ] `go test ./internal/controller/...` — blocked locally by missing `/usr/local/kubebuilder/bin/etcd` (envtest); to be verified in CI
- [ ] Manual verification in a dev cluster: confirm `scheduled scaling activated` / `scheduled scaling deactivated` fire at Info and that `activeSchedules` appears on the PU update log when a schedule is in effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)