### PR TITLE
feat: Cloud Monitoring quota fallback on Spanner ResourceExhausted

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,7 +496,9 @@ The endpoint can be scraped by Prometheus (`ServiceMonitor` / `PodMonitor`), the
 | Name | Type | Extra labels | Description |
 |---|---|---|---|
 | `spanner_autoscaler_instance_update_total` | Counter | `result=success\|error` | Spanner `UpdateInstance` API call count. |
+| `spanner_autoscaler_instance_update_errors_total` | Counter | `grpc_code` | Failed Spanner `UpdateInstance` API calls by gRPC code, e.g. `resource_exhausted`, `permission_denied`, `unknown`. |
 | `spanner_autoscaler_instance_update_duration_seconds` | Histogram | — | Latency of `UpdateInstance` calls. Buckets: 0.1, 0.5, 1, 2, 5, 10, 30, 60. |
+| `spanner_autoscaler_quota_lookup_total` | Counter | `result=success\|error\|skipped`, `reason` | Cloud Monitoring quota lookup count after `RESOURCE_EXHAUSTED`, e.g. `ok`, `permission_denied`, `unsupported_instance_config`, `no_data`. |
 | `spanner_autoscaler_metrics_fetch_total` | Counter | `result=success\|error` | Cloud Monitoring `GetInstanceMetrics` call count. |
 | `spanner_autoscaler_metrics_fetch_duration_seconds` | Histogram | — | Latency of Cloud Monitoring fetches. Buckets: 0.05, 0.1, 0.25, 0.5, 1, 2, 5. |
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -146,7 +146,7 @@ else:
 if ENABLE_WEBHOOKS:
     local_resource(
         'controller',
-        serve_cmd='go run ./cmd/main.go -zap-devel --cert-dir={} {}'.format(WEBHOOK_CERT_DIR, EMULATOR_FLAGS),
+        serve_cmd='go run ./cmd/main.go -zap-devel --webhook-cert-path={} {}'.format(WEBHOOK_CERT_DIR, EMULATOR_FLAGS),
         deps=['cmd/', 'api/', 'internal/'],
         resource_deps=['dev-certs'],
         labels=['controller'],

--- a/cmd/monitoring-emulator/main.go
+++ b/cmd/monitoring-emulator/main.go
@@ -29,6 +29,8 @@ func main() {
 	staticStore := monitoringemulator.NewStaticStore()
 	workloadStore := monitoringemulator.NewWorkloadStore()
 	scenarioStore := monitoringemulator.NewScenarioStore()
+	quotaStore := monitoringemulator.NewQuotaStore()
+	quotaModeStore := monitoringemulator.NewQuotaModeStore()
 
 	if scenarioFile != "" {
 		if err := scenarioStore.LoadFile(scenarioFile); err != nil {
@@ -59,7 +61,7 @@ func main() {
 		logger.Info("dynamic mode disabled: SPANNER_EMULATOR_HOST not set")
 	}
 
-	srv := monitoringemulator.NewMetricServiceServer(staticStore, workloadStore, scenarioStore, spannerAdminClient)
+	srv := monitoringemulator.NewMetricServiceServer(staticStore, workloadStore, scenarioStore, quotaStore, quotaModeStore, spannerAdminClient)
 
 	// Start gRPC server.
 	grpcLis, err := net.Listen("tcp", ":"+grpcPort)
@@ -78,7 +80,7 @@ func main() {
 	}()
 
 	// Start HTTP admin server.
-	adminHandler := monitoringemulator.NewAdminHandler(staticStore, workloadStore, scenarioStore)
+	adminHandler := monitoringemulator.NewAdminHandler(staticStore, workloadStore, scenarioStore, quotaStore, quotaModeStore)
 	adminSrv := &http.Server{ //nolint:gosec
 		Addr:    ":" + adminPort,
 		Handler: adminHandler,

--- a/docs/development.md
+++ b/docs/development.md
@@ -97,6 +97,17 @@ Spanner instances must be created via the admin HTTP API before the controller c
 $ curl -X PUT http://localhost:9011/instances/beta-project/beta-instance \
     -H 'Content-Type: application/json' \
     -d '{"processing_units": 1000}'
+
+# Create an instance with an explicit Spanner instance config
+$ curl -X PUT http://localhost:9011/instances/beta-project/beta-instance \
+    -H 'Content-Type: application/json' \
+    -d '{"processing_units": 1000, "config": "projects/beta-project/instanceConfigs/regional-asia-northeast1"}'
+
+# Make UpdateInstance return ResourceExhausted when aggregate PU for this
+# project/config exceeds the configured quota.
+$ curl -X PUT http://localhost:9011/quota/beta-project/regional-asia-northeast1 \
+    -H 'Content-Type: application/json' \
+    -d '{"processing_units": 100000}'
 ```
 
 #### Monitoring emulator
@@ -113,6 +124,7 @@ spanner-autoscaler calls only one RPC method from the [MetricService API](https:
 | RPC | Used in | Purpose |
 |---|---|---|
 | `MetricService.ListTimeSeries` | `metrics.Client.GetInstanceMetrics` | Fetch `spanner.googleapis.com/instance/cpu/utilization_by_priority` (priority=`high`) or `spanner.googleapis.com/instance/cpu/utilization` (total) for the target instance |
+| `MetricService.ListTimeSeries` | `metrics.Client.GetQuota` | Fetch `serviceruntime.googleapis.com/quota/limit` and `serviceruntime.googleapis.com/quota/allocation/usage` after Spanner `UpdateInstance` returns `ResourceExhausted` |
 
 All other `MetricService` methods (`CreateTimeSeries`, `ListMetricDescriptors`, etc.) are **not implemented** and return `Unimplemented`.
 
@@ -201,6 +213,27 @@ $ curl -X DELETE http://localhost:9091/metrics/beta-project/beta-instance
 ```
 
 If no mode is configured for an instance, the controller logs `no such spanner instance metrics` and skips scaling for that cycle.
+
+**Quota metrics**
+
+The Monitoring emulator can also return the quota time series used by the ResourceExhausted fallback. These quota metrics are independent from the CPU modes above. Configure a `consumer_quota` entry per project/location:
+
+```console
+# Regional instance config: regional-asia-northeast1
+$ curl -X PUT http://localhost:9091/quota/beta-project/asia-northeast1 \
+    -H 'Content-Type: application/json' \
+    -d '{"quotaMetric": "spanner.googleapis.com/nodes", "limitName": "SpannerNodesPerProject", "limitNodes": 100, "usageNodes": 1}'
+
+# Multi-region or dual-region instance config, for example nam6:
+$ curl -X PUT http://localhost:9091/quota/beta-project/global \
+    -H 'Content-Type: application/json' \
+    -d '{"quotaMetric": "spanner.googleapis.com/nodes_nam6", "limitName": "NodesNam6PerProject", "limitNodes": 25, "usageNodes": 0}'
+
+# Remove
+$ curl -X DELETE http://localhost:9091/quota/beta-project/asia-northeast1
+```
+
+To verify quota fallback end to end, configure the Spanner emulator instance with the target `config`, set a Spanner emulator quota low enough to make `UpdateInstance` return `ResourceExhausted`, and set the matching Monitoring emulator quota metrics. The controller then uses the config returned by `GetInstance` to select the Monitoring quota series, emits `spanner_autoscaler_instance_update_errors_total{grpc_code="resource_exhausted"}`, emits `spanner_autoscaler_quota_lookup_total`, and retries once with the largest PU value that fits the observed quota.
 
 ### Webhook mode (default)
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -257,7 +257,7 @@ If you prefer not to use Tilt, you can run the full webhook development loop man
    ```console
    $ make run-dev
    ```
-   `run-dev` automatically extracts the webhook TLS certificate from the cluster into `bin/webhook-certs/` and starts the controller with `--cert-dir` pointing to that directory.
+   `run-dev` automatically extracts the webhook TLS certificate from the cluster into `bin/webhook-certs/` and starts the controller with `--webhook-cert-path` pointing to that directory.
 
 1. Apply sample resources:
    ```console

--- a/internal/controller/spannerautoscaler_controller.go
+++ b/internal/controller/spannerautoscaler_controller.go
@@ -461,23 +461,21 @@ func (r *SpannerAutoscalerReconciler) Reconcile(ctx context.Context, req ctrlrec
 		)
 
 		labels := observability.LabelsForAutoscaler(&sa)
-		updateStart := r.clock.Now()
-		updateErr := syncer.UpdateInstance(ctx, desiredProcessingUnits)
-		observability.RecordInstanceUpdate(labels, r.clock.Now().Sub(updateStart), updateErr)
+		appliedProcessingUnits, updateErr := syncer.UpdateInstance(ctx, desiredProcessingUnits)
 		if updateErr != nil {
 			r.recorder.Event(&sa, corev1.EventTypeWarning, "FailedUpdateInstance", updateErr.Error())
 			log.Error(updateErr, "failed to update spanner instance")
 			return ctrlreconcile.Result{}, updateErr
 		}
 		observability.RecordScaleEvent(labels,
-			sa.Status.CurrentProcessingUnits, desiredProcessingUnits,
-			scaleDriver(&sa, desiredProcessingUnits),
+			sa.Status.CurrentProcessingUnits, appliedProcessingUnits,
+			scaleDriver(&sa, appliedProcessingUnits),
 		)
 
 		r.recorder.Eventf(&sa, corev1.EventTypeNormal, "Updated",
 			"Updated processing units of %s/%s from %d to %d (currentCPUMetricType=%s, currentHighPriorityCPUUtilization=%d%%, currentTotalCPUUtilization=%d%%, highPriorityTarget=%d%%, totalTarget=%d%%)",
 			sa.Spec.TargetInstance.ProjectID, sa.Spec.TargetInstance.InstanceID,
-			sa.Status.CurrentProcessingUnits, desiredProcessingUnits,
+			sa.Status.CurrentProcessingUnits, appliedProcessingUnits,
 			sa.Status.CurrentCPUMetricType,
 			sa.Status.CurrentHighPriorityCPUUtilization, sa.Status.CurrentTotalCPUUtilization,
 			highPriorityTarget, totalTarget,
@@ -485,7 +483,8 @@ func (r *SpannerAutoscalerReconciler) Reconcile(ctx context.Context, req ctrlrec
 
 		log.Info("updated processing units via google cloud api",
 			"before", sa.Status.CurrentProcessingUnits,
-			"after", desiredProcessingUnits,
+			"after", appliedProcessingUnits,
+			"calculatedDesiredPU", desiredProcessingUnits,
 			"currentCPUMetricType", sa.Status.CurrentCPUMetricType,
 			"currentHighPriorityCPUUtilization", sa.Status.CurrentHighPriorityCPUUtilization,
 			"currentTotalCPUUtilization", sa.Status.CurrentTotalCPUUtilization,

--- a/internal/controller/spannerautoscaler_controller_test.go
+++ b/internal/controller/spannerautoscaler_controller_test.go
@@ -1000,21 +1000,14 @@ var _ = Describe("Cron mutability", func() {
 			spReconciler.syncers[saNN] = &fakesyncer.Syncer{}
 			spReconciler.mu.Unlock()
 
-			By("creating the SpannerAutoscaleSchedule with initial cron '0 * * * *'")
-			sched := &spannerv1beta1.SpannerAutoscaleSchedule{
-				ObjectMeta: metav1.ObjectMeta{Name: schedName, Namespace: namespace},
-				Spec: spannerv1beta1.SpannerAutoscaleScheduleSpec{
-					TargetResource:            saName,
-					AdditionalProcessingUnits: 1000,
-					Schedule: spannerv1beta1.Schedule{
-						Cron:     "0 * * * *",
-						Duration: "1h",
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, sched)).To(Succeed())
-
-			By("creating the SpannerAutoscaler")
+			By("creating the SpannerAutoscaler before the schedule")
+			// Order matters: SetupWithManager registers a watch that enqueues a
+			// SpannerAutoscaler reconcile for sched.Spec.TargetResource. If the
+			// schedule is created first, that reconcile fires before the SA
+			// exists, hits the NotFound branch, and deletes the fake syncer we
+			// just pre-seeded — the subsequent reconciles then try to spin up a
+			// real syncer and fail without GCP credentials. Create the SA first
+			// so the watcher's reconcile sees an existing resource.
 			sa := &spannerv1beta1.SpannerAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{Name: saName, Namespace: namespace},
 				Spec: spannerv1beta1.SpannerAutoscalerSpec{
@@ -1040,7 +1033,22 @@ var _ = Describe("Cron mutability", func() {
 			}
 			Expect(k8sClient.Create(ctx, sa)).To(Succeed())
 
+			By("creating the SpannerAutoscaleSchedule with initial cron '0 * * * *'")
+			sched := &spannerv1beta1.SpannerAutoscaleSchedule{
+				ObjectMeta: metav1.ObjectMeta{Name: schedName, Namespace: namespace},
+				Spec: spannerv1beta1.SpannerAutoscaleScheduleSpec{
+					TargetResource:            saName,
+					AdditionalProcessingUnits: 1000,
+					Schedule: spannerv1beta1.Schedule{
+						Cron:     "0 * * * *",
+						Duration: "1h",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, sched)).To(Succeed())
+
 			By("setting Status.Schedules to include the schedule")
+			Expect(k8sClient.Get(ctx, saNN, sa)).To(Succeed())
 			sa.Status.Schedules = []string{schedNN.String()}
 			Expect(k8sClient.Status().Update(ctx, sa)).To(Succeed())
 

--- a/internal/metrics/fake.go
+++ b/internal/metrics/fake.go
@@ -9,7 +9,9 @@ import (
 // FakeClient implements Client but operates fake objects for testing.
 // This ensure thread-safety.
 type FakeClient struct {
-	metrics *InstanceMetrics
+	metrics  *InstanceMetrics
+	quota    *Quota
+	quotaErr error
 
 	mu sync.RWMutex
 }
@@ -23,6 +25,19 @@ func NewFakeClient(metrics *InstanceMetrics) *FakeClient {
 		metrics: metrics,
 		mu:      sync.RWMutex{},
 	}
+}
+
+func (c *FakeClient) SetQuota(quota *Quota) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.quota = quota
+	c.quotaErr = nil
+}
+
+func (c *FakeClient) SetQuotaError(err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.quotaErr = err
 }
 
 // GetInstanceMetrics implements Client.
@@ -39,4 +54,23 @@ func (c *FakeClient) GetInstanceMetrics(ctx context.Context, metricType MetricTy
 	default: // MetricTypeHighPriority
 		return &InstanceMetrics{CurrentHighPriorityCPUUtilization: c.metrics.CurrentHighPriorityCPUUtilization}, nil
 	}
+}
+
+// GetQuota implements Client.
+func (c *FakeClient) GetQuota(_ context.Context, _ string, _ time.Time) (*Quota, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.quotaErr != nil {
+		return nil, c.quotaErr
+	}
+	if c.quota == nil {
+		return nil, ErrQuotaNoData
+	}
+	return &Quota{
+		LimitNodes:  c.quota.LimitNodes,
+		UsageNodes:  c.quota.UsageNodes,
+		QuotaMetric: c.quota.QuotaMetric,
+		LimitName:   c.quota.LimitName,
+		Location:    c.quota.Location,
+	}, nil
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -47,6 +47,15 @@ type InstanceMetrics struct {
 	CurrentTotalCPUUtilization int
 }
 
+// Quota represents Spanner node quota limit and allocation usage from Cloud Monitoring.
+type Quota struct {
+	LimitNodes  int64
+	UsageNodes  int64
+	QuotaMetric string
+	LimitName   string
+	Location    string
+}
+
 // Client is a client for manipulation of InstanceMetrics.
 type Client interface {
 	// GetInstanceMetrics gets the instance metrics for the given metric type.
@@ -56,6 +65,8 @@ type Client interface {
 	// same now to each call so the underlying Cloud Monitoring queries hit
 	// the same alignment window.
 	GetInstanceMetrics(ctx context.Context, metricType MetricType, now time.Time) (*InstanceMetrics, error)
+	// GetQuota gets Spanner node quota limit and allocation usage for the instance config.
+	GetQuota(ctx context.Context, instanceConfig string, now time.Time) (*Quota, error)
 }
 
 // client is a client for Stackdriver Monitoring.
@@ -65,6 +76,7 @@ type client struct {
 	projectID  string
 	instanceID string
 	term       time.Duration
+	quotaTerm  time.Duration
 
 	endpoint    string
 	tokenSource oauth2.TokenSource
@@ -106,6 +118,7 @@ func NewClient(ctx context.Context, projectID, instanceID string, opts ...Option
 		projectID:  projectID,
 		instanceID: instanceID,
 		term:       10 * time.Minute,
+		quotaTerm:  6 * time.Hour,
 		log:        logr.Discard(),
 	}
 

--- a/internal/metrics/quota.go
+++ b/internal/metrics/quota.go
@@ -1,0 +1,209 @@
+package metrics
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	monitoringpb "cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
+	"github.com/golang/protobuf/ptypes/duration"
+	"github.com/golang/protobuf/ptypes/timestamp"
+	"google.golang.org/api/iterator"
+)
+
+const (
+	spannerService                 = "spanner.googleapis.com"
+	quotaLimitMetricType           = "serviceruntime.googleapis.com/quota/limit"
+	quotaAllocationUsageMetricType = "serviceruntime.googleapis.com/quota/allocation/usage"
+	regionalConfigPrefix           = "regional-"
+	customConfigPrefix             = "custom-"
+	defaultRegionalQuotaMetric     = "spanner.googleapis.com/nodes"
+	defaultRegionalLimitName       = "SpannerNodesPerProject"
+)
+
+var (
+	ErrUnsupportedInstanceConfig = errors.New("unsupported spanner instance configuration")
+	ErrQuotaNoData               = errors.New("quota metrics not found")
+	ErrQuotaMalformedResponse    = errors.New("quota metrics response is malformed")
+)
+
+// quotaTarget describes what to look for in Cloud Monitoring's quota time series.
+// location is empty for multi/dual-region configs, where it is discovered from
+// the limit query and reused for the usage query. limitName is empty for non-
+// regional configs and is filled in from the limit time series's label.
+type quotaTarget struct {
+	configID    string
+	quotaMetric string
+	location    string
+	limitName   string
+}
+
+// GetQuota implements Client.
+func (c *client) GetQuota(ctx context.Context, instanceConfig string, now time.Time) (*Quota, error) {
+	target, err := resolveQuotaTarget(instanceConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	log := c.log.WithValues(
+		"instance-id", c.instanceID,
+		"project-id", c.projectID,
+		"instance-config", instanceConfig,
+		"config-id", target.configID,
+		"quota-metric", target.quotaMetric,
+	)
+
+	// For regional, target.location is already the pre-derived region and is
+	// used as the filter for both queries. For multi/dual-region it is empty
+	// here, the limit query accepts any location, and we adopt the location
+	// returned by Monitoring before issuing the usage query.
+	limit, err := c.findQuotaTimeSeries(ctx, quotaLimitMetricType, target, target.location, now)
+	if err != nil {
+		log.Info("Could not get Spanner quota limit", "error", err)
+		return nil, err
+	}
+	if limit.limitName != "" {
+		target.limitName = limit.limitName
+	}
+	if target.location == "" {
+		target.location = limit.location
+	}
+
+	usage, err := c.findQuotaTimeSeries(ctx, quotaAllocationUsageMetricType, target, target.location, now)
+	if err != nil {
+		log.Info("Could not get Spanner quota usage", "error", err)
+		return nil, err
+	}
+
+	return &Quota{
+		LimitNodes:  limit.value,
+		UsageNodes:  usage.value,
+		QuotaMetric: target.quotaMetric,
+		LimitName:   target.limitName,
+		Location:    target.location,
+	}, nil
+}
+
+type quotaTimeSeries struct {
+	value     int64
+	location  string
+	limitName string
+}
+
+func (c *client) findQuotaTimeSeries(ctx context.Context, metricType string, target quotaTarget, location string, now time.Time) (*quotaTimeSeries, error) {
+	nowUTC := now.UTC()
+	req := &monitoringpb.ListTimeSeriesRequest{
+		Name:   fmt.Sprintf("projects/%s", c.projectID),
+		Filter: quotaFilter(metricType),
+		Interval: &monitoringpb.TimeInterval{
+			StartTime: &timestamp.Timestamp{Seconds: nowUTC.Add(-c.quotaTerm).Unix()},
+			EndTime:   &timestamp.Timestamp{Seconds: nowUTC.Unix()},
+		},
+		Aggregation: &monitoringpb.Aggregation{
+			AlignmentPeriod:  &duration.Duration{Seconds: int64(c.quotaTerm.Seconds())},
+			PerSeriesAligner: monitoringpb.Aggregation_ALIGN_NEXT_OLDER,
+		},
+		View:     monitoringpb.ListTimeSeriesRequest_FULL,
+		PageSize: 1000,
+	}
+
+	it := c.monitoringMetricClient.ListTimeSeries(ctx, req)
+	for {
+		ts, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if !matchesQuotaTarget(ts, target, location) {
+			continue
+		}
+		value, err := quotaPointValue(ts.GetPoints())
+		if err != nil {
+			return nil, err
+		}
+		resource := ts.GetResource()
+		metric := ts.GetMetric()
+		return &quotaTimeSeries{
+			value:     value,
+			location:  resource.GetLabels()["location"],
+			limitName: metric.GetLabels()["limit_name"],
+		}, nil
+	}
+
+	return nil, fmt.Errorf("%w: metric_type=%s quota_metric=%s location=%s", ErrQuotaNoData, metricType, target.quotaMetric, location)
+}
+
+func quotaFilter(metricType string) string {
+	return fmt.Sprintf("metric.type = %q AND resource.type = %q AND resource.labels.service = %q", metricType, "consumer_quota", spannerService)
+}
+
+// matchesQuotaTarget filters time series by the target's quota_metric and
+// (when known) limit_name labels. locationFilter restricts the resource
+// location label; pass "" to accept any location (used by the limit query for
+// multi/dual-region configs where the location is discovered, not pre-derived).
+func matchesQuotaTarget(ts *monitoringpb.TimeSeries, target quotaTarget, locationFilter string) bool {
+	metricLabels := ts.GetMetric().GetLabels()
+	if metricLabels["quota_metric"] != target.quotaMetric {
+		return false
+	}
+	if target.limitName != "" {
+		if got := metricLabels["limit_name"]; got != "" && got != target.limitName {
+			return false
+		}
+	}
+	if locationFilter != "" && ts.GetResource().GetLabels()["location"] != locationFilter {
+		return false
+	}
+	return true
+}
+
+func quotaPointValue(points []*monitoringpb.Point) (int64, error) {
+	if len(points) == 0 || points[0].GetValue() == nil {
+		return 0, ErrQuotaMalformedResponse
+	}
+	value := points[0].GetValue()
+	switch v := value.GetValue().(type) {
+	case *monitoringpb.TypedValue_Int64Value:
+		return v.Int64Value, nil
+	case *monitoringpb.TypedValue_DoubleValue:
+		if math.Trunc(v.DoubleValue) != v.DoubleValue {
+			return 0, ErrQuotaMalformedResponse
+		}
+		return int64(v.DoubleValue), nil
+	default:
+		return 0, ErrQuotaMalformedResponse
+	}
+}
+
+func resolveQuotaTarget(instanceConfig string) (quotaTarget, error) {
+	configID := instanceConfig
+	if i := strings.LastIndex(instanceConfig, "/"); i >= 0 {
+		configID = instanceConfig[i+1:]
+	}
+	if configID == "" || strings.HasPrefix(configID, customConfigPrefix) {
+		return quotaTarget{configID: configID}, fmt.Errorf("%w: %s", ErrUnsupportedInstanceConfig, instanceConfig)
+	}
+
+	if strings.HasPrefix(configID, regionalConfigPrefix) {
+		location := strings.TrimPrefix(configID, regionalConfigPrefix)
+		if location == "" {
+			return quotaTarget{configID: configID}, fmt.Errorf("%w: %s", ErrUnsupportedInstanceConfig, instanceConfig)
+		}
+		return quotaTarget{
+			configID:    configID,
+			quotaMetric: defaultRegionalQuotaMetric,
+			location:    location,
+			limitName:   defaultRegionalLimitName,
+		}, nil
+	}
+
+	return quotaTarget{
+		configID:    configID,
+		quotaMetric: "spanner.googleapis.com/nodes_" + strings.ReplaceAll(configID, "-", "_"),
+	}, nil
+}

--- a/internal/metrics/quota_test.go
+++ b/internal/metrics/quota_test.go
@@ -1,0 +1,77 @@
+package metrics
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestResolveQuotaTarget(t *testing.T) {
+	tests := []struct {
+		name            string
+		instanceConfig  string
+		wantQuotaMetric string
+		wantLocation    string
+		wantLimitName   string
+		wantUnsupported bool
+	}{
+		{
+			name:            "regional",
+			instanceConfig:  "projects/p/instanceConfigs/regional-asia-northeast1",
+			wantQuotaMetric: "spanner.googleapis.com/nodes",
+			wantLocation:    "asia-northeast1",
+			wantLimitName:   "SpannerNodesPerProject",
+		},
+		{
+			name:            "multi region",
+			instanceConfig:  "projects/p/instanceConfigs/nam6",
+			wantQuotaMetric: "spanner.googleapis.com/nodes_nam6",
+		},
+		{
+			name:            "multi region with hyphens",
+			instanceConfig:  "projects/p/instanceConfigs/nam-eur-asia1",
+			wantQuotaMetric: "spanner.googleapis.com/nodes_nam_eur_asia1",
+		},
+		{
+			name:            "dual region",
+			instanceConfig:  "projects/p/instanceConfigs/dual-region-japan1",
+			wantQuotaMetric: "spanner.googleapis.com/nodes_dual_region_japan1",
+		},
+		{
+			name:            "custom unsupported",
+			instanceConfig:  "projects/p/instanceConfigs/custom-foo",
+			wantUnsupported: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveQuotaTarget(tt.instanceConfig)
+			if tt.wantUnsupported {
+				if !errors.Is(err, ErrUnsupportedInstanceConfig) {
+					t.Fatalf("resolveQuotaTarget() error = %v, want ErrUnsupportedInstanceConfig", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveQuotaTarget() error = %v", err)
+			}
+			if got.quotaMetric != tt.wantQuotaMetric {
+				t.Errorf("quotaMetric = %q, want %q", got.quotaMetric, tt.wantQuotaMetric)
+			}
+			if got.location != tt.wantLocation {
+				t.Errorf("location = %q, want %q", got.location, tt.wantLocation)
+			}
+			if got.limitName != tt.wantLimitName {
+				t.Errorf("limitName = %q, want %q", got.limitName, tt.wantLimitName)
+			}
+		})
+	}
+}
+
+func TestQuotaFilter(t *testing.T) {
+	got := quotaFilter(quotaLimitMetricType)
+	want := `metric.type = "serviceruntime.googleapis.com/quota/limit" AND resource.type = "consumer_quota" AND resource.labels.service = "spanner.googleapis.com"`
+	if got != want {
+		t.Errorf("quotaFilter() = %q, want %q", got, want)
+	}
+}

--- a/internal/monitoringemulator/admin.go
+++ b/internal/monitoringemulator/admin.go
@@ -33,7 +33,19 @@ import (
 //	                    "total":         {"cpu_utilization": 0.50}}, ...]}
 //	  At least one of high_priority or total must be set per step.
 //	DELETE /scenario/{project_id}/{instance_id}
-func NewAdminHandler(staticStore *StaticStore, workloadStore *WorkloadStore, scenarioStore *ScenarioStore) http.Handler {
+//
+// Quota mode endpoints:
+//
+//	PUT    /quota/{project_id}/{location}
+//	  Body: {"quotaMetric": "spanner.googleapis.com/nodes", "limitName": "SpannerNodesPerProject", "limitNodes": 100, "usageNodes": 1}
+//	DELETE /quota/{project_id}/{location}
+//
+// Quota failure-injection endpoints (apply to all quota metric queries):
+//
+//	PUT    /quota-mode
+//	  Body: {"grpcCode": "PermissionDenied", "message": "permission denied"}
+//	DELETE /quota-mode
+func NewAdminHandler(staticStore *StaticStore, workloadStore *WorkloadStore, scenarioStore *ScenarioStore, quotaStore *QuotaStore, quotaModeStore *QuotaModeStore) http.Handler {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("PUT /metrics/{project_id}/{instance_id}", handleStaticSet(staticStore))
@@ -46,6 +58,12 @@ func NewAdminHandler(staticStore *StaticStore, workloadStore *WorkloadStore, sce
 
 	mux.HandleFunc("PUT /scenario/{project_id}/{instance_id}", handleScenarioSet(scenarioStore))
 	mux.HandleFunc("DELETE /scenario/{project_id}/{instance_id}", handleScenarioDelete(scenarioStore))
+
+	mux.HandleFunc("PUT /quota/{project_id}/{location}", handleQuotaSet(quotaStore))
+	mux.HandleFunc("DELETE /quota/{project_id}/{location}", handleQuotaDelete(quotaStore))
+
+	mux.HandleFunc("PUT /quota-mode", handleQuotaModeSet(quotaModeStore))
+	mux.HandleFunc("DELETE /quota-mode", handleQuotaModeDelete(quotaModeStore))
 
 	return mux
 }
@@ -130,6 +148,77 @@ func handleStaticGet(store *StaticStore) http.HandlerFunc {
 func handleStaticDelete(store *StaticStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		store.Delete(r.PathValue("project_id"), r.PathValue("instance_id"))
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// ---- quota mode ----
+
+func handleQuotaSet(store *QuotaStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		projectID := r.PathValue("project_id")
+		location := r.PathValue("location")
+
+		var req QuotaEntry
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if req.QuotaMetric == "" {
+			http.Error(w, "quotaMetric is required", http.StatusBadRequest)
+			return
+		}
+		if req.LimitNodes <= 0 {
+			http.Error(w, "limitNodes must be greater than 0", http.StatusBadRequest)
+			return
+		}
+		if req.UsageNodes < 0 {
+			http.Error(w, "usageNodes must be greater than or equal to 0", http.StatusBadRequest)
+			return
+		}
+
+		store.Set(projectID, location, req)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(req) //nolint:errcheck,gosec
+	}
+}
+
+func handleQuotaDelete(store *QuotaStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		store.Delete(r.PathValue("project_id"), r.PathValue("location"))
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+type quotaModeRequest struct {
+	GrpcCode string `json:"grpcCode"`
+	Message  string `json:"message"`
+}
+
+func handleQuotaModeSet(store *QuotaModeStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req quotaModeRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if req.GrpcCode == "" {
+			http.Error(w, "grpcCode is required", http.StatusBadRequest)
+			return
+		}
+		code, err := ParseGrpcCode(req.GrpcCode)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		store.Set(code, req.Message)
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func handleQuotaModeDelete(store *QuotaModeStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		store.Clear()
 		w.WriteHeader(http.StatusNoContent)
 	}
 }

--- a/internal/monitoringemulator/admin_test.go
+++ b/internal/monitoringemulator/admin_test.go
@@ -1,0 +1,74 @@
+package monitoringemulator
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+)
+
+func newTestAdminHandler() (*QuotaModeStore, http.Handler) {
+	staticStore := NewStaticStore()
+	workloadStore := NewWorkloadStore()
+	scenarioStore := NewScenarioStore()
+	quotaStore := NewQuotaStore()
+	quotaModeStore := NewQuotaModeStore()
+	return quotaModeStore, NewAdminHandler(staticStore, workloadStore, scenarioStore, quotaStore, quotaModeStore)
+}
+
+func TestAdmin_QuotaMode_SetAndDelete(t *testing.T) {
+	store, handler := newTestAdminHandler()
+
+	req := httptest.NewRequest(http.MethodPut, "/quota-mode",
+		strings.NewReader(`{"grpcCode":"PermissionDenied","message":"denied"}`))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("PUT /quota-mode status = %d, want %d; body=%q", rec.Code, http.StatusNoContent, rec.Body.String())
+	}
+	mode, ok := store.Get()
+	if !ok {
+		t.Fatal("store should have a mode set")
+	}
+	if mode.Code != codes.PermissionDenied || mode.Message != "denied" {
+		t.Errorf("stored mode = %+v, want PermissionDenied/denied", mode)
+	}
+
+	req = httptest.NewRequest(http.MethodDelete, "/quota-mode", http.NoBody)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("DELETE /quota-mode status = %d, want %d", rec.Code, http.StatusNoContent)
+	}
+	if _, ok := store.Get(); ok {
+		t.Error("store should be cleared after DELETE")
+	}
+}
+
+func TestAdmin_QuotaMode_BadRequests(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "invalid json", body: `{not json`},
+		{name: "missing grpcCode", body: `{"message":"x"}`},
+		{name: "empty grpcCode", body: `{"grpcCode":"","message":"x"}`},
+		{name: "unknown grpcCode", body: `{"grpcCode":"NotARealCode"}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, handler := newTestAdminHandler()
+			req := httptest.NewRequest(http.MethodPut, "/quota-mode", strings.NewReader(tt.body))
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400; body=%q", rec.Code, rec.Body.String())
+			}
+			if _, ok := store.Get(); ok {
+				t.Errorf("store should remain empty after a bad request")
+			}
+		})
+	}
+}

--- a/internal/monitoringemulator/filter.go
+++ b/internal/monitoringemulator/filter.go
@@ -11,6 +11,10 @@ var (
 		`metric\.type\s*=\s*"spanner\.googleapis\.com/instance/cpu/utilization_by_priority"`)
 	metricTypeTotalPattern = regexp.MustCompile(
 		`metric\.type\s*=\s*"spanner\.googleapis\.com/instance/cpu/utilization"`)
+	metricTypeQuotaLimitPattern = regexp.MustCompile(
+		`metric\.type\s*=\s*"serviceruntime\.googleapis\.com/quota/limit"`)
+	metricTypeQuotaUsagePattern = regexp.MustCompile(
+		`metric\.type\s*=\s*"serviceruntime\.googleapis\.com/quota/allocation/usage"`)
 )
 
 // MetricKind represents the kind of Cloud Monitoring metric in a filter string.
@@ -19,6 +23,8 @@ type MetricKind int
 const (
 	MetricKindHighPriority MetricKind = iota
 	MetricKindTotal
+	MetricKindQuotaLimit
+	MetricKindQuotaUsage
 	MetricKindUnknown
 )
 
@@ -29,6 +35,10 @@ func extractMetricKind(filter string) MetricKind {
 		return MetricKindHighPriority
 	case metricTypeTotalPattern.MatchString(filter):
 		return MetricKindTotal
+	case metricTypeQuotaLimitPattern.MatchString(filter):
+		return MetricKindQuotaLimit
+	case metricTypeQuotaUsagePattern.MatchString(filter):
+		return MetricKindQuotaUsage
 	default:
 		return MetricKindUnknown
 	}

--- a/internal/monitoringemulator/filter_test.go
+++ b/internal/monitoringemulator/filter_test.go
@@ -73,6 +73,16 @@ func TestExtractMetricKind(t *testing.T) {
 			want:   MetricKindUnknown,
 		},
 		{
+			name:   "quota limit",
+			filter: `metric.type = "serviceruntime.googleapis.com/quota/limit" AND resource.type = "consumer_quota"`,
+			want:   MetricKindQuotaLimit,
+		},
+		{
+			name:   "quota allocation usage",
+			filter: `metric.type = "serviceruntime.googleapis.com/quota/allocation/usage" AND resource.type = "consumer_quota"`,
+			want:   MetricKindQuotaUsage,
+		},
+		{
 			name:   "empty filter",
 			filter: "",
 			want:   MetricKindUnknown,

--- a/internal/monitoringemulator/quota_mode_store.go
+++ b/internal/monitoringemulator/quota_mode_store.go
@@ -1,0 +1,61 @@
+package monitoringemulator
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"google.golang.org/grpc/codes"
+)
+
+// QuotaMode causes quota metric queries to return the configured gRPC code
+// instead of a successful TimeSeries response. Set via the admin API to
+// exercise the controller's quota-lookup degrade paths in integration tests.
+type QuotaMode struct {
+	Code    codes.Code
+	Message string
+}
+
+// QuotaModeStore holds at most one QuotaMode. Empty means quota queries use
+// the QuotaStore normally.
+type QuotaModeStore struct {
+	mu   sync.RWMutex
+	mode *QuotaMode
+}
+
+func NewQuotaModeStore() *QuotaModeStore {
+	return &QuotaModeStore{}
+}
+
+func (s *QuotaModeStore) Set(code codes.Code, message string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mode = &QuotaMode{Code: code, Message: message}
+}
+
+func (s *QuotaModeStore) Clear() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mode = nil
+}
+
+func (s *QuotaModeStore) Get() (QuotaMode, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.mode == nil {
+		return QuotaMode{}, false
+	}
+	return *s.mode, true
+}
+
+// ParseGrpcCode maps a case-insensitive gRPC code name (matching the Code's
+// String()) to its codes.Code value. Returns an error for unknown names.
+func ParseGrpcCode(name string) (codes.Code, error) {
+	normalized := strings.ToLower(strings.TrimSpace(name))
+	for code := codes.OK; code <= codes.Unauthenticated; code++ {
+		if strings.ToLower(code.String()) == normalized {
+			return code, nil
+		}
+	}
+	return codes.OK, fmt.Errorf("unknown gRPC code %q", name)
+}

--- a/internal/monitoringemulator/quota_store.go
+++ b/internal/monitoringemulator/quota_store.go
@@ -1,0 +1,50 @@
+package monitoringemulator
+
+import "sync"
+
+type QuotaEntry struct {
+	QuotaMetric string `json:"quotaMetric"`
+	LimitName   string `json:"limitName"`
+	LimitNodes  int64  `json:"limitNodes"`
+	UsageNodes  int64  `json:"usageNodes"`
+}
+
+type quotaKey struct {
+	project  string
+	location string
+}
+
+type QuotaStore struct {
+	mu   sync.RWMutex
+	data map[quotaKey]QuotaEntry
+}
+
+func NewQuotaStore() *QuotaStore {
+	return &QuotaStore{
+		data: make(map[quotaKey]QuotaEntry),
+	}
+}
+
+func (s *QuotaStore) Set(project, location string, entry QuotaEntry) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[quotaKey{project: project, location: location}] = entry
+}
+
+func (s *QuotaStore) List(project string) map[string]QuotaEntry {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make(map[string]QuotaEntry)
+	for key, entry := range s.data {
+		if key.project == project {
+			out[key.location] = entry
+		}
+	}
+	return out
+}
+
+func (s *QuotaStore) Delete(project, location string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.data, quotaKey{project: project, location: location})
+}

--- a/internal/monitoringemulator/server.go
+++ b/internal/monitoringemulator/server.go
@@ -9,6 +9,9 @@ import (
 	monitoringpb "cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
 	spanneradmin "cloud.google.com/go/spanner/admin/instance/apiv1"
 	instancepb "cloud.google.com/go/spanner/admin/instance/apiv1/instancepb"
+	metricpb "google.golang.org/genproto/googleapis/api/metric"
+	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -40,6 +43,8 @@ type MetricServiceServer struct {
 	staticStore        *StaticStore
 	workloadStore      *WorkloadStore
 	scenarioStore      *ScenarioStore
+	quotaStore         *QuotaStore
+	quotaModeStore     *QuotaModeStore
 	spannerAdminClient *spanneradmin.InstanceAdminClient // nil → dynamic mode unavailable
 }
 
@@ -47,12 +52,16 @@ func NewMetricServiceServer(
 	staticStore *StaticStore,
 	workloadStore *WorkloadStore,
 	scenarioStore *ScenarioStore,
+	quotaStore *QuotaStore,
+	quotaModeStore *QuotaModeStore,
 	spannerAdminClient *spanneradmin.InstanceAdminClient,
 ) *MetricServiceServer {
 	return &MetricServiceServer{
 		staticStore:        staticStore,
 		workloadStore:      workloadStore,
 		scenarioStore:      scenarioStore,
+		quotaStore:         quotaStore,
+		quotaModeStore:     quotaModeStore,
 		spannerAdminClient: spannerAdminClient,
 	}
 }
@@ -65,14 +74,23 @@ func (s *MetricServiceServer) ListTimeSeries(
 	if err != nil {
 		return nil, err
 	}
-	instanceID, err := extractInstanceID(req.GetFilter())
-	if err != nil {
-		return nil, err
-	}
 
 	kind := extractMetricKind(req.GetFilter())
 	if kind == MetricKindUnknown {
 		return nil, fmt.Errorf("unsupported metric type in filter: %s", req.GetFilter())
+	}
+	if kind == MetricKindQuotaLimit || kind == MetricKindQuotaUsage {
+		if s.quotaModeStore != nil {
+			if mode, ok := s.quotaModeStore.Get(); ok {
+				return nil, status.Error(mode.Code, mode.Message)
+			}
+		}
+		return buildQuotaResponse(projectID, kind, s.quotaStore), nil
+	}
+
+	instanceID, err := extractInstanceID(req.GetFilter())
+	if err != nil {
+		return nil, err
 	}
 
 	// Priority 1: ScenarioStore (time-based scenario mode)
@@ -155,4 +173,56 @@ func buildResponse(cpuUtilization float64) *monitoringpb.ListTimeSeriesResponse 
 			},
 		},
 	}
+}
+
+func buildQuotaResponse(projectID string, kind MetricKind, store *QuotaStore) *monitoringpb.ListTimeSeriesResponse {
+	if store == nil {
+		return &monitoringpb.ListTimeSeriesResponse{}
+	}
+
+	now := time.Now()
+	entries := store.List(projectID)
+	resp := &monitoringpb.ListTimeSeriesResponse{
+		TimeSeries: make([]*monitoringpb.TimeSeries, 0, len(entries)),
+	}
+	for location, entry := range entries {
+		metricLabels := map[string]string{
+			"quota_metric": entry.QuotaMetric,
+		}
+		value := entry.UsageNodes
+		metricType := "serviceruntime.googleapis.com/quota/allocation/usage"
+		if kind == MetricKindQuotaLimit {
+			metricType = "serviceruntime.googleapis.com/quota/limit"
+			metricLabels["limit_name"] = entry.LimitName
+			value = entry.LimitNodes
+		}
+		resp.TimeSeries = append(resp.TimeSeries, &monitoringpb.TimeSeries{
+			Metric: &metricpb.Metric{
+				Type:   metricType,
+				Labels: metricLabels,
+			},
+			Resource: &monitoredrespb.MonitoredResource{
+				Type: "consumer_quota",
+				Labels: map[string]string{
+					"project_id": projectID,
+					"service":    "spanner.googleapis.com",
+					"location":   location,
+				},
+			},
+			Points: []*monitoringpb.Point{
+				{
+					Interval: &monitoringpb.TimeInterval{
+						StartTime: timestamppb.New(now),
+						EndTime:   timestamppb.New(now),
+					},
+					Value: &monitoringpb.TypedValue{
+						Value: &monitoringpb.TypedValue_Int64Value{
+							Int64Value: value,
+						},
+					},
+				},
+			},
+		})
+	}
+	return resp
 }

--- a/internal/monitoringemulator/server_test.go
+++ b/internal/monitoringemulator/server_test.go
@@ -1,0 +1,103 @@
+package monitoringemulator
+
+import (
+	"context"
+	"testing"
+
+	monitoringpb "cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestBuildQuotaResponse(t *testing.T) {
+	store := NewQuotaStore()
+	store.Set("proj", "asia-northeast1", QuotaEntry{
+		QuotaMetric: "spanner.googleapis.com/nodes",
+		LimitName:   "SpannerNodesPerProject",
+		LimitNodes:  100,
+		UsageNodes:  1,
+	})
+
+	limitResp := buildQuotaResponse("proj", MetricKindQuotaLimit, store)
+	if len(limitResp.GetTimeSeries()) != 1 {
+		t.Fatalf("limit time series count = %d, want 1", len(limitResp.GetTimeSeries()))
+	}
+	limitTS := limitResp.GetTimeSeries()[0]
+	if got := limitTS.GetMetric().GetType(); got != "serviceruntime.googleapis.com/quota/limit" {
+		t.Errorf("limit metric type = %q", got)
+	}
+	if got := limitTS.GetMetric().GetLabels()["quota_metric"]; got != "spanner.googleapis.com/nodes" {
+		t.Errorf("quota_metric = %q", got)
+	}
+	if got := limitTS.GetMetric().GetLabels()["limit_name"]; got != "SpannerNodesPerProject" {
+		t.Errorf("limit_name = %q", got)
+	}
+	if got := limitTS.GetResource().GetLabels()["location"]; got != "asia-northeast1" {
+		t.Errorf("location = %q", got)
+	}
+	if got := limitTS.GetPoints()[0].GetValue().GetInt64Value(); got != 100 {
+		t.Errorf("limit value = %d, want 100", got)
+	}
+
+	usageResp := buildQuotaResponse("proj", MetricKindQuotaUsage, store)
+	if len(usageResp.GetTimeSeries()) != 1 {
+		t.Fatalf("usage time series count = %d, want 1", len(usageResp.GetTimeSeries()))
+	}
+	usageTS := usageResp.GetTimeSeries()[0]
+	if got := usageTS.GetMetric().GetType(); got != "serviceruntime.googleapis.com/quota/allocation/usage" {
+		t.Errorf("usage metric type = %q", got)
+	}
+	if got := usageTS.GetMetric().GetLabels()["limit_name"]; got != "" {
+		t.Errorf("usage limit_name = %q, want empty", got)
+	}
+	if got := usageTS.GetPoints()[0].GetValue().GetInt64Value(); got != 1 {
+		t.Errorf("usage value = %d, want 1", got)
+	}
+}
+
+func TestListTimeSeries_QuotaModeReturnsError(t *testing.T) {
+	staticStore := NewStaticStore()
+	workloadStore := NewWorkloadStore()
+	scenarioStore := NewScenarioStore()
+	quotaStore := NewQuotaStore()
+	quotaModeStore := NewQuotaModeStore()
+	quotaStore.Set("proj", "asia-northeast1", QuotaEntry{
+		QuotaMetric: "spanner.googleapis.com/nodes",
+		LimitName:   "SpannerNodesPerProject",
+		LimitNodes:  100,
+		UsageNodes:  1,
+	})
+
+	srv := NewMetricServiceServer(staticStore, workloadStore, scenarioStore, quotaStore, quotaModeStore, nil)
+
+	limitReq := &monitoringpb.ListTimeSeriesRequest{
+		Name:   "projects/proj",
+		Filter: `metric.type = "serviceruntime.googleapis.com/quota/limit" AND resource.type = "consumer_quota"`,
+	}
+	usageReq := &monitoringpb.ListTimeSeriesRequest{
+		Name:   "projects/proj",
+		Filter: `metric.type = "serviceruntime.googleapis.com/quota/allocation/usage" AND resource.type = "consumer_quota"`,
+	}
+
+	// No mode set yet → success
+	if _, err := srv.ListTimeSeries(context.Background(), limitReq); err != nil {
+		t.Fatalf("ListTimeSeries(limit) before mode = %v, want nil", err)
+	}
+
+	// Mode set → returns the configured error
+	quotaModeStore.Set(codes.PermissionDenied, "permission denied")
+	_, err := srv.ListTimeSeries(context.Background(), limitReq)
+	if status.Code(err) != codes.PermissionDenied {
+		t.Errorf("ListTimeSeries(limit) under mode code = %v, want PermissionDenied; err=%v", status.Code(err), err)
+	}
+	_, err = srv.ListTimeSeries(context.Background(), usageReq)
+	if status.Code(err) != codes.PermissionDenied {
+		t.Errorf("ListTimeSeries(usage) under mode code = %v, want PermissionDenied; err=%v", status.Code(err), err)
+	}
+
+	// Clear → success again
+	quotaModeStore.Clear()
+	if _, err := srv.ListTimeSeries(context.Background(), limitReq); err != nil {
+		t.Errorf("ListTimeSeries(limit) after clear = %v, want nil", err)
+	}
+}

--- a/internal/monitoringemulator/store_test.go
+++ b/internal/monitoringemulator/store_test.go
@@ -2,6 +2,8 @@ package monitoringemulator
 
 import (
 	"testing"
+
+	"google.golang.org/grpc/codes"
 )
 
 func floatPtr(f float64) *float64 { return &f }
@@ -75,6 +77,95 @@ func TestWorkloadStore_NotFound(t *testing.T) {
 	s := NewWorkloadStore()
 	if _, ok := s.Get("proj", "inst", MetricKindHighPriority); ok {
 		t.Error("expected not found")
+	}
+}
+
+// ---- QuotaStore ----
+
+func TestQuotaStore_ListByProject(t *testing.T) {
+	s := NewQuotaStore()
+	s.Set("proj", "asia-northeast1", QuotaEntry{
+		QuotaMetric: "spanner.googleapis.com/nodes",
+		LimitName:   "SpannerNodesPerProject",
+		LimitNodes:  100,
+		UsageNodes:  1,
+	})
+	s.Set("other", "asia-northeast1", QuotaEntry{
+		QuotaMetric: "spanner.googleapis.com/nodes",
+		LimitName:   "SpannerNodesPerProject",
+		LimitNodes:  40,
+	})
+
+	got := s.List("proj")
+	entry, ok := got["asia-northeast1"]
+	if !ok {
+		t.Fatal("expected quota entry for proj/asia-northeast1")
+	}
+	if entry.LimitNodes != 100 || entry.UsageNodes != 1 {
+		t.Errorf("quota entry = %+v, want limit=100 usage=1", entry)
+	}
+	if _, ok := got["other"]; ok {
+		t.Error("unexpected quota entry from another project")
+	}
+}
+
+func TestQuotaStore_Delete(t *testing.T) {
+	s := NewQuotaStore()
+	s.Set("proj", "asia-northeast1", QuotaEntry{QuotaMetric: "spanner.googleapis.com/nodes", LimitNodes: 100})
+	s.Delete("proj", "asia-northeast1")
+	if got := s.List("proj"); len(got) != 0 {
+		t.Errorf("expected no quota entries after delete, got %v", got)
+	}
+}
+
+// ---- QuotaModeStore ----
+
+func TestQuotaModeStore_SetGetClear(t *testing.T) {
+	s := NewQuotaModeStore()
+
+	if _, ok := s.Get(); ok {
+		t.Fatal("expected no mode set initially")
+	}
+
+	s.Set(codes.PermissionDenied, "permission denied")
+	mode, ok := s.Get()
+	if !ok {
+		t.Fatal("expected mode to be set")
+	}
+	if mode.Code != codes.PermissionDenied || mode.Message != "permission denied" {
+		t.Errorf("mode = %+v", mode)
+	}
+
+	s.Clear()
+	if _, ok := s.Get(); ok {
+		t.Error("expected mode to be cleared")
+	}
+}
+
+func TestParseGrpcCode(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    codes.Code
+		wantErr bool
+	}{
+		{name: "PermissionDenied", input: "PermissionDenied", want: codes.PermissionDenied},
+		{name: "case insensitive", input: "permissiondenied", want: codes.PermissionDenied},
+		{name: "Unavailable", input: "Unavailable", want: codes.Unavailable},
+		{name: "ResourceExhausted", input: "ResourceExhausted", want: codes.ResourceExhausted},
+		{name: "Unauthenticated", input: "Unauthenticated", want: codes.Unauthenticated},
+		{name: "unknown", input: "NotARealCode", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseGrpcCode(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -13,9 +13,13 @@
 package observability
 
 import (
+	"strings"
 	"time"
+	"unicode"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/types"
 
 	spannerv1beta1 "github.com/mercari/spanner-autoscaler/api/v1beta1"
@@ -32,6 +36,7 @@ const (
 	driverLabel    = "driver"
 	reasonLabel    = "reason"
 	resultLabel    = "result"
+	grpcCodeLabel  = "grpc_code"
 
 	cpuTypeHighPriority = "high_priority"
 	cpuTypeTotal        = "total"
@@ -57,6 +62,21 @@ const (
 
 	resultSuccess = "success"
 	resultError   = "error"
+
+	QuotaLookupResultSuccess = resultSuccess
+	QuotaLookupResultError   = resultError
+	QuotaLookupResultSkipped = "skipped"
+
+	QuotaLookupReasonOK                        = "ok"
+	QuotaLookupReasonPermissionDenied          = "permission_denied"
+	QuotaLookupReasonUnauthenticated           = "unauthenticated"
+	QuotaLookupReasonUnavailable               = "unavailable"
+	QuotaLookupReasonResourceExhausted         = "resource_exhausted"
+	QuotaLookupReasonTimeout                   = "timeout"
+	QuotaLookupReasonUnsupportedInstanceConfig = "unsupported_instance_config"
+	QuotaLookupReasonNoData                    = "no_data"
+	QuotaLookupReasonMalformedResponse         = "malformed_response"
+	QuotaLookupReasonUnknown                   = "unknown"
 )
 
 // identityLabels is the ordered label set attached to every business metric.
@@ -227,11 +247,21 @@ var (
 		Help: "Spanner UpdateInstance API call count, labeled by result (success|error).",
 	}, append(identityLabels, resultLabel))
 
+	instanceUpdateErrorsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "spanner_autoscaler_instance_update_errors_total",
+		Help: "Spanner UpdateInstance API error count, labeled by gRPC code.",
+	}, append(identityLabels, grpcCodeLabel))
+
 	instanceUpdateDurationSeconds = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "spanner_autoscaler_instance_update_duration_seconds",
 		Help:    "Spanner UpdateInstance API call latency in seconds.",
 		Buckets: []float64{0.1, 0.5, 1, 2, 5, 10, 30, 60},
 	}, identityLabels)
+
+	quotaLookupTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "spanner_autoscaler_quota_lookup_total",
+		Help: "Cloud Monitoring quota lookup count after ResourceExhausted, labeled by result and reason.",
+	}, append(identityLabels, resultLabel, reasonLabel))
 
 	metricsFetchTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "spanner_autoscaler_metrics_fetch_total",
@@ -268,7 +298,9 @@ func allCollectors() []prometheus.Collector {
 		scaleSkippedTotal,
 		scalePUDelta,
 		instanceUpdateTotal,
+		instanceUpdateErrorsTotal,
 		instanceUpdateDurationSeconds,
+		quotaLookupTotal,
 		metricsFetchTotal,
 		metricsFetchDurationSeconds,
 	}
@@ -302,7 +334,9 @@ func allVectors() []partialDeleter {
 		scaleSkippedTotal,
 		scalePUDelta,
 		instanceUpdateTotal,
+		instanceUpdateErrorsTotal,
 		instanceUpdateDurationSeconds,
+		quotaLookupTotal,
 		metricsFetchTotal,
 		metricsFetchDurationSeconds,
 	}
@@ -408,6 +442,14 @@ func RecordScheduleDeactivation(l Labels, reason string) {
 func RecordInstanceUpdate(l Labels, duration time.Duration, err error) {
 	instanceUpdateDurationSeconds.WithLabelValues(l.values()...).Observe(duration.Seconds())
 	instanceUpdateTotal.WithLabelValues(l.withExtra(resultFor(err))...).Inc()
+	if err != nil {
+		instanceUpdateErrorsTotal.WithLabelValues(l.withExtra(grpcCodeFor(err))...).Inc()
+	}
+}
+
+// RecordQuotaLookup records a ResourceExhausted-triggered quota lookup result.
+func RecordQuotaLookup(l Labels, result, reason string) {
+	quotaLookupTotal.WithLabelValues(l.withExtra(result, reason)...).Inc()
 }
 
 // RecordMetricsFetch records the latency and result of a Cloud Monitoring
@@ -432,4 +474,29 @@ func resultFor(err error) string {
 		return resultSuccess
 	}
 	return resultError
+}
+
+func grpcCodeFor(err error) string {
+	code := status.Code(err)
+	if code == codes.OK {
+		return "unknown"
+	}
+	return grpcCodeSnake(code.String())
+}
+
+// grpcCodeSnake converts a gRPC code's CamelCase String() (e.g. "ResourceExhausted")
+// to snake_case ("resource_exhausted") for use as a Prometheus label value.
+func grpcCodeSnake(s string) string {
+	var b strings.Builder
+	for i, r := range s {
+		if unicode.IsUpper(r) {
+			if i > 0 {
+				b.WriteByte('_')
+			}
+			b.WriteRune(unicode.ToLower(r))
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
 }

--- a/internal/observability/metrics_test.go
+++ b/internal/observability/metrics_test.go
@@ -16,6 +16,8 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/common/model"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	spannerv1beta1 "github.com/mercari/spanner-autoscaler/api/v1beta1"
@@ -134,7 +136,9 @@ func TestRecordInstanceUpdate_ResultMapping(t *testing.T) {
 	teardown(t, l)
 
 	RecordInstanceUpdate(l, 50*time.Millisecond, nil)
-	RecordInstanceUpdate(l, 2*time.Second, errors.New("boom"))
+	RecordInstanceUpdate(l, 2*time.Second, status.Error(codes.ResourceExhausted, "quota exceeded"))
+	// Plain non-gRPC error: status.Code reports codes.Unknown → "unknown" label.
+	RecordInstanceUpdate(l, 100*time.Millisecond, errors.New("boom"))
 
 	if got := testutil.ToFloat64(instanceUpdateTotal.WithLabelValues(
 		l.Namespace, l.Name, l.ProjectID, l.InstanceID, resultSuccess,
@@ -143,8 +147,57 @@ func TestRecordInstanceUpdate_ResultMapping(t *testing.T) {
 	}
 	if got := testutil.ToFloat64(instanceUpdateTotal.WithLabelValues(
 		l.Namespace, l.Name, l.ProjectID, l.InstanceID, resultError,
+	)); got != 2 {
+		t.Errorf("error count = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(instanceUpdateErrorsTotal.WithLabelValues(
+		l.Namespace, l.Name, l.ProjectID, l.InstanceID, "resource_exhausted",
 	)); got != 1 {
-		t.Errorf("error count = %v, want 1", got)
+		t.Errorf("resource_exhausted error count = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(instanceUpdateErrorsTotal.WithLabelValues(
+		l.Namespace, l.Name, l.ProjectID, l.InstanceID, "unknown",
+	)); got != 1 {
+		t.Errorf("unknown error count = %v, want 1", got)
+	}
+}
+
+func TestGrpcCodeSnake(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"ResourceExhausted", "resource_exhausted"},
+		{"PermissionDenied", "permission_denied"},
+		{"Unavailable", "unavailable"},
+		{"OK", "o_k"}, // not used in practice (grpcCodeFor short-circuits), but documents the conversion rule
+		{"", ""},
+		{"already_snake", "already_snake"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := grpcCodeSnake(tt.in); got != tt.want {
+				t.Errorf("grpcCodeSnake(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRecordQuotaLookup_ResultMapping(t *testing.T) {
+	l := labelsFor("quota")
+	teardown(t, l)
+
+	RecordQuotaLookup(l, QuotaLookupResultSuccess, QuotaLookupReasonOK)
+	RecordQuotaLookup(l, QuotaLookupResultSkipped, QuotaLookupReasonUnsupportedInstanceConfig)
+
+	if got := testutil.ToFloat64(quotaLookupTotal.WithLabelValues(
+		l.Namespace, l.Name, l.ProjectID, l.InstanceID, QuotaLookupResultSuccess, QuotaLookupReasonOK,
+	)); got != 1 {
+		t.Errorf("quota lookup success count = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(quotaLookupTotal.WithLabelValues(
+		l.Namespace, l.Name, l.ProjectID, l.InstanceID, QuotaLookupResultSkipped, QuotaLookupReasonUnsupportedInstanceConfig,
+	)); got != 1 {
+		t.Errorf("quota lookup skipped count = %v, want 1", got)
 	}
 }
 
@@ -356,6 +409,8 @@ func TestMetricsHTTPExposition(t *testing.T) {
 	RecordScheduleActivation(l)
 	RecordScheduleDeactivation(l, ScheduleDeactivationExpired)
 	RecordInstanceUpdate(l, 250*time.Millisecond, nil)
+	RecordInstanceUpdate(l, 260*time.Millisecond, status.Error(codes.ResourceExhausted, "quota exceeded"))
+	RecordQuotaLookup(l, QuotaLookupResultSkipped, QuotaLookupReasonUnsupportedInstanceConfig)
 	RecordMetricsFetch(l, 80*time.Millisecond, nil)
 
 	srv := httptest.NewServer(promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))

--- a/internal/spanner/fake.go
+++ b/internal/spanner/fake.go
@@ -28,13 +28,17 @@ func NewFakeClient(instance *Instance) *FakeClient {
 func (c *FakeClient) GetInstance(ctx context.Context) (*Instance, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.instance, nil
+	return &Instance{
+		ProcessingUnits: c.instance.ProcessingUnits,
+		InstanceState:   c.instance.InstanceState,
+		Config:          c.instance.Config,
+	}, nil
 }
 
 // UpdateInstance implements Client.
 func (c *FakeClient) UpdateInstance(ctx context.Context, instance *Instance) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.instance = instance
+	c.instance.ProcessingUnits = instance.ProcessingUnits
 	return nil
 }

--- a/internal/spanner/fake/fake.go
+++ b/internal/spanner/fake/fake.go
@@ -14,6 +14,7 @@ type Client struct {
 	mu              sync.Mutex
 	processingUnits int
 	instanceState   spanner.State
+	config          string
 }
 
 var _ spanner.Client = (*Client)(nil)
@@ -22,6 +23,7 @@ func NewClient(processingUnits int) *Client {
 	return &Client{
 		processingUnits: processingUnits,
 		instanceState:   spanner.StateReady,
+		config:          "projects/fake-project/instanceConfigs/regional-asia-northeast1",
 	}
 }
 
@@ -31,6 +33,7 @@ func (c *Client) GetInstance(_ context.Context) (*spanner.Instance, error) {
 	return &spanner.Instance{
 		ProcessingUnits: c.processingUnits,
 		InstanceState:   c.instanceState,
+		Config:          c.config,
 	}, nil
 }
 

--- a/internal/spanner/spanner.go
+++ b/internal/spanner/spanner.go
@@ -30,6 +30,7 @@ const (
 type Instance struct {
 	ProcessingUnits int
 	InstanceState   State
+	Config          string
 }
 
 // Client is a client for manipulation of Instance.
@@ -125,30 +126,29 @@ func (c *client) GetInstance(ctx context.Context) (*Instance, error) {
 	return &Instance{
 		ProcessingUnits: int(i.ProcessingUnits),
 		InstanceState:   instanceState(i.State),
+		Config:          i.GetConfig(),
 	}, nil
 }
 
 // UpdateInstance implements Client.
+//
+// Only processing_units is mutated, so the request carries a minimal Instance
+// (Name + ProcessingUnits) with FieldMask=["processing_units"]. There is no
+// pre-flight GetInstance: the field mask makes a full instance round-trip
+// unnecessary, and on ResourceExhausted the syncer fetches the instance once
+// for fallback math instead of paying for it on every UpdateInstance attempt.
 func (c *client) UpdateInstance(ctx context.Context, instance *Instance) error {
 	log := c.log.WithValues("instance-id", c.instanceID, "project-id", c.projectID)
 
-	log.V(1).Info("getting spanner instance")
-	i, err := c.spannerInstanceAdminClient.GetInstance(ctx, &instancepb.GetInstanceRequest{
-		Name: fmt.Sprintf(instanceNameFormat, c.projectID, c.instanceID),
-	})
-	if err != nil {
-		log.Error(err, "unable to get spanner instance")
-		return err
-	}
+	name := fmt.Sprintf(instanceNameFormat, c.projectID, c.instanceID)
+	log.V(1).Info("updating spanner instance", "patch", instance)
 
-	log.V(1).Info("got spanner instance", "received instance", i, "patch", instance)
-
-	//nolint:gosec // G115
-	i.ProcessingUnits = int32(instance.ProcessingUnits)
-	log.V(1).Info("updating spanner instance", "desired instance", i, "patch", instance)
-
-	_, err = c.spannerInstanceAdminClient.UpdateInstance(ctx, &instancepb.UpdateInstanceRequest{
-		Instance: i,
+	_, err := c.spannerInstanceAdminClient.UpdateInstance(ctx, &instancepb.UpdateInstanceRequest{
+		Instance: &instancepb.Instance{
+			Name: name,
+			//nolint:gosec // G115
+			ProcessingUnits: int32(instance.ProcessingUnits),
+		},
 		FieldMask: &field_mask.FieldMask{
 			Paths: []string{"processing_units"},
 		},
@@ -157,7 +157,7 @@ func (c *client) UpdateInstance(ctx context.Context, instance *Instance) error {
 		log.Error(err, "unable to update spanner instance")
 		return err
 	}
-	log.V(1).Info("updated spanner instance", "desired instance", i, "applied patch", instance)
+	log.V(1).Info("updated spanner instance", "applied patch", instance)
 
 	return nil
 }

--- a/internal/spanneremulator/admin.go
+++ b/internal/spanneremulator/admin.go
@@ -8,22 +8,31 @@ import (
 
 // NewAdminHandler returns an HTTP handler for the Spanner emulator admin API.
 //
-//	PUT    /instances/{project_id}/{instance_id}   {"processing_units": 1000}
+//	PUT    /instances/{project_id}/{instance_id}   {"processing_units": 1000, "config": "projects/p/instanceConfigs/regional-asia-northeast1"}
 //	DELETE /instances/{project_id}/{instance_id}
+//	PUT    /quota/{project_id}/{config_id}         {"processing_units": 100000}
+//	DELETE /quota/{project_id}/{config_id}
+//
+// processingUnits is also accepted for Kubernetes-style JSON payloads.
 func NewAdminHandler(srv *Server) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /instances/{project_id}/{instance_id}", handleUpsert(srv))
 	mux.HandleFunc("DELETE /instances/{project_id}/{instance_id}", handleDelete(srv))
+	mux.HandleFunc("PUT /quota/{project_id}/{config_id}", handleQuotaSet(srv))
+	mux.HandleFunc("DELETE /quota/{project_id}/{config_id}", handleQuotaDelete(srv))
 	return mux
 }
 
 type upsertRequest struct {
-	ProcessingUnits int32 `json:"processing_units"`
+	ProcessingUnits      int32  `json:"processing_units"`
+	ProcessingUnitsCamel int32  `json:"processingUnits"`
+	Config               string `json:"config"`
 }
 
 type instanceResponse struct {
 	Name            string `json:"name"`
 	ProcessingUnits int32  `json:"processing_units"`
+	Config          string `json:"config"`
 }
 
 func handleUpsert(srv *Server) http.HandlerFunc {
@@ -36,18 +45,24 @@ func handleUpsert(srv *Server) http.HandlerFunc {
 			http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
 			return
 		}
-		if req.ProcessingUnits <= 0 {
+		processingUnits := req.processingUnits()
+		if processingUnits <= 0 {
 			http.Error(w, "processing_units must be greater than 0", http.StatusBadRequest)
 			return
 		}
 
 		name := fmt.Sprintf("projects/%s/instances/%s", projectID, instanceID)
-		srv.AdminUpsertInstance(name, req.ProcessingUnits)
+		config := req.Config
+		if config == "" {
+			config = fmt.Sprintf("projects/%s/instanceConfigs/regional-asia-northeast1", projectID)
+		}
+		srv.AdminUpsertInstance(name, processingUnits, config)
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(instanceResponse{ //nolint:errcheck,gosec
 			Name:            name,
-			ProcessingUnits: req.ProcessingUnits,
+			ProcessingUnits: processingUnits,
+			Config:          config,
 		})
 	}
 }
@@ -60,4 +75,39 @@ func handleDelete(srv *Server) http.HandlerFunc {
 		srv.AdminDeleteInstance(name)
 		w.WriteHeader(http.StatusNoContent)
 	}
+}
+
+func handleQuotaSet(srv *Server) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		projectID := r.PathValue("project_id")
+		configID := r.PathValue("config_id")
+
+		var req upsertRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		processingUnits := req.processingUnits()
+		if processingUnits <= 0 {
+			http.Error(w, "processing_units must be greater than 0", http.StatusBadRequest)
+			return
+		}
+
+		srv.AdminSetQuota(projectID, configID, processingUnits)
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func handleQuotaDelete(srv *Server) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		srv.AdminDeleteQuota(r.PathValue("project_id"), r.PathValue("config_id"))
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func (r upsertRequest) processingUnits() int32 {
+	if r.ProcessingUnits != 0 {
+		return r.ProcessingUnits
+	}
+	return r.ProcessingUnitsCamel
 }

--- a/internal/spanneremulator/server.go
+++ b/internal/spanneremulator/server.go
@@ -17,6 +17,7 @@ package spanneremulator
 
 import (
 	"context"
+	"strings"
 	"sync"
 
 	longrunningpb "cloud.google.com/go/longrunning/autogen/longrunningpb"
@@ -32,12 +33,14 @@ type Server struct {
 
 	mu        sync.RWMutex
 	instances map[string]*instancepb.Instance // key: "projects/{p}/instances/{i}"
+	quotas    map[string]int32                // key: "projects/{p}/instanceConfigs/{config_id}"
 }
 
 // NewServer returns a new Server with an empty instance store.
 func NewServer() *Server {
 	return &Server{
 		instances: make(map[string]*instancepb.Instance),
+		quotas:    make(map[string]int32),
 	}
 }
 
@@ -69,36 +72,97 @@ func (s *Server) UpdateInstance(_ context.Context, req *instancepb.UpdateInstanc
 		return nil, status.Errorf(codes.NotFound, "instance %q not found", patch.GetName())
 	}
 
-	if mask := req.GetFieldMask(); mask != nil {
-		for _, path := range mask.GetPaths() {
-			switch path {
-			case "processing_units":
-				existing.ProcessingUnits = patch.ProcessingUnits
-			case "node_count":
-				existing.NodeCount = patch.NodeCount
-			case "display_name":
-				existing.DisplayName = patch.DisplayName
+	// A nil/empty field mask means "update every supported field" (mirrors the
+	// real Spanner Admin API). Otherwise apply only the named paths.
+	paths := req.GetFieldMask().GetPaths()
+	willUpdate := func(field string) bool {
+		if len(paths) == 0 {
+			return true
+		}
+		for _, p := range paths {
+			if p == field {
+				return true
 			}
 		}
-	} else {
+		return false
+	}
+
+	updatedProcessingUnits := existing.ProcessingUnits
+	if willUpdate("processing_units") {
+		updatedProcessingUnits = patch.ProcessingUnits
+	}
+	if err := s.checkQuotaLocked(existing, updatedProcessingUnits); err != nil {
+		return nil, err
+	}
+
+	if willUpdate("processing_units") {
 		existing.ProcessingUnits = patch.ProcessingUnits
+	}
+	if willUpdate("node_count") {
 		existing.NodeCount = patch.NodeCount
+	}
+	if willUpdate("display_name") {
 		existing.DisplayName = patch.DisplayName
 	}
 
 	return completedOperation(existing)
 }
 
+func (s *Server) checkQuotaLocked(target *instancepb.Instance, updatedProcessingUnits int32) error {
+	projectID := projectIDFromInstanceName(target.GetName())
+	configID := configIDFromConfigName(target.GetConfig())
+	if projectID == "" || configID == "" {
+		return nil
+	}
+
+	quotaKey := quotaStoreKey(projectID, configID)
+	quota, ok := s.quotas[quotaKey]
+	if !ok {
+		return nil
+	}
+
+	var total int32
+	for _, inst := range s.instances {
+		if projectIDFromInstanceName(inst.GetName()) != projectID || configIDFromConfigName(inst.GetConfig()) != configID {
+			continue
+		}
+		if inst.GetName() == target.GetName() {
+			total += updatedProcessingUnits
+			continue
+		}
+		total += inst.GetProcessingUnits()
+	}
+	if total > quota {
+		return status.Errorf(codes.ResourceExhausted, "Project cannot add nodes for instance config %s", configID)
+	}
+	return nil
+}
+
 // AdminUpsertInstance creates or replaces an instance. Used by the HTTP admin API.
-func (s *Server) AdminUpsertInstance(name string, processingUnits int32) {
+func (s *Server) AdminUpsertInstance(name string, processingUnits int32, config string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.instances[name] = &instancepb.Instance{
 		Name:            name,
 		DisplayName:     name,
 		ProcessingUnits: processingUnits,
+		Config:          config,
 		State:           instancepb.Instance_READY,
 	}
+}
+
+// AdminSetQuota sets a processing-units quota for a project/config pair.
+func (s *Server) AdminSetQuota(projectID, configID string, processingUnits int32) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.quotas[quotaStoreKey(projectID, configID)] = processingUnits
+}
+
+// AdminDeleteQuota removes a processing-units quota for a project/config pair.
+func (s *Server) AdminDeleteQuota(projectID, configID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.quotas, quotaStoreKey(projectID, configID))
 }
 
 // AdminDeleteInstance removes an instance. Used by the HTTP admin API.
@@ -106,6 +170,31 @@ func (s *Server) AdminDeleteInstance(name string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.instances, name)
+}
+
+func quotaStoreKey(projectID, configID string) string {
+	return projectID + "/" + configID
+}
+
+func projectIDFromInstanceName(name string) string {
+	const prefix = "projects/"
+	if !strings.HasPrefix(name, prefix) {
+		return ""
+	}
+	rest := strings.TrimPrefix(name, prefix)
+	parts := strings.SplitN(rest, "/", 2)
+	if len(parts) != 2 {
+		return ""
+	}
+	return parts[0]
+}
+
+func configIDFromConfigName(config string) string {
+	i := strings.LastIndex(config, "/")
+	if i < 0 {
+		return config
+	}
+	return config[i+1:]
 }
 
 // completedOperation wraps inst in an already-Done LRO response.

--- a/internal/spanneremulator/server_test.go
+++ b/internal/spanneremulator/server_test.go
@@ -1,0 +1,106 @@
+package spanneremulator
+
+import (
+	"context"
+	"testing"
+
+	instancepb "cloud.google.com/go/spanner/admin/instance/apiv1/instancepb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+)
+
+func TestUpdateInstance_QuotaResourceExhausted(t *testing.T) {
+	srv := NewServer()
+	config := "projects/proj/instanceConfigs/regional-asia-northeast1"
+	srv.AdminUpsertInstance("projects/proj/instances/target", 100, config)
+	srv.AdminSetQuota("proj", "regional-asia-northeast1", 100000)
+
+	_, err := srv.UpdateInstance(context.Background(), &instancepb.UpdateInstanceRequest{
+		Instance: &instancepb.Instance{
+			Name:            "projects/proj/instances/target",
+			ProcessingUnits: 101000,
+		},
+		FieldMask: &fieldmaskpb.FieldMask{Paths: []string{"processing_units"}},
+	})
+	if status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("UpdateInstance() code = %v, want ResourceExhausted; err=%v", status.Code(err), err)
+	}
+}
+
+func TestUpdateInstance_QuotaAllowsWithinLimit(t *testing.T) {
+	srv := NewServer()
+	config := "projects/proj/instanceConfigs/regional-asia-northeast1"
+	srv.AdminUpsertInstance("projects/proj/instances/target", 100, config)
+	srv.AdminSetQuota("proj", "regional-asia-northeast1", 100000)
+
+	_, err := srv.UpdateInstance(context.Background(), &instancepb.UpdateInstanceRequest{
+		Instance: &instancepb.Instance{
+			Name:            "projects/proj/instances/target",
+			ProcessingUnits: 100000,
+		},
+		FieldMask: &fieldmaskpb.FieldMask{Paths: []string{"processing_units"}},
+	})
+	if err != nil {
+		t.Fatalf("UpdateInstance() error = %v", err)
+	}
+}
+
+// TestUpdateInstance_QuotaAggregatesAcrossInstances verifies that the
+// emulator's quota check sums PU across all instances sharing the same
+// project/config — mirroring how Cloud Spanner quotas actually behave.
+// 30000 (target after update) + 15000 (other) = 45000 > 40000 → RE.
+func TestUpdateInstance_QuotaAggregatesAcrossInstances(t *testing.T) {
+	srv := NewServer()
+	config := "projects/proj/instanceConfigs/regional-asia-northeast1"
+	srv.AdminUpsertInstance("projects/proj/instances/target", 10000, config)
+	srv.AdminUpsertInstance("projects/proj/instances/other", 15000, config)
+	srv.AdminSetQuota("proj", "regional-asia-northeast1", 40000)
+
+	// 30000 + 15000 = 45000 → over quota.
+	_, err := srv.UpdateInstance(context.Background(), &instancepb.UpdateInstanceRequest{
+		Instance: &instancepb.Instance{
+			Name:            "projects/proj/instances/target",
+			ProcessingUnits: 30000,
+		},
+		FieldMask: &fieldmaskpb.FieldMask{Paths: []string{"processing_units"}},
+	})
+	if status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("UpdateInstance over aggregate quota code = %v, want ResourceExhausted; err=%v", status.Code(err), err)
+	}
+
+	// 25000 + 15000 = 40000 → exactly at quota, must succeed.
+	_, err = srv.UpdateInstance(context.Background(), &instancepb.UpdateInstanceRequest{
+		Instance: &instancepb.Instance{
+			Name:            "projects/proj/instances/target",
+			ProcessingUnits: 25000,
+		},
+		FieldMask: &fieldmaskpb.FieldMask{Paths: []string{"processing_units"}},
+	})
+	if err != nil {
+		t.Fatalf("UpdateInstance at aggregate quota cap = %v, want nil", err)
+	}
+}
+
+// TestUpdateInstance_QuotaIgnoresOtherConfigs ensures the aggregate is scoped
+// to project + config_id. A large instance in a different instance config must
+// not count against the regional quota.
+func TestUpdateInstance_QuotaIgnoresOtherConfigs(t *testing.T) {
+	srv := NewServer()
+	srv.AdminUpsertInstance("projects/proj/instances/target", 100,
+		"projects/proj/instanceConfigs/regional-asia-northeast1")
+	srv.AdminUpsertInstance("projects/proj/instances/other", 90000,
+		"projects/proj/instanceConfigs/regional-us-central1")
+	srv.AdminSetQuota("proj", "regional-asia-northeast1", 40000)
+
+	_, err := srv.UpdateInstance(context.Background(), &instancepb.UpdateInstanceRequest{
+		Instance: &instancepb.Instance{
+			Name:            "projects/proj/instances/target",
+			ProcessingUnits: 40000,
+		},
+		FieldMask: &fieldmaskpb.FieldMask{Paths: []string{"processing_units"}},
+	})
+	if err != nil {
+		t.Fatalf("UpdateInstance with cross-config instance = %v, want nil", err)
+	}
+}

--- a/internal/syncer/fake/fake.go
+++ b/internal/syncer/fake/fake.go
@@ -14,17 +14,21 @@ type Syncer struct {
 var _ syncer.Syncer = (*Syncer)(nil)
 
 func (s *Syncer) Start() {
-	s.FakeStart()
+	if s.FakeStart != nil {
+		s.FakeStart()
+	}
 }
 
 func (s *Syncer) Stop() {
-	s.FakeStop()
+	if s.FakeStop != nil {
+		s.FakeStop()
+	}
 }
 
 func (s *Syncer) HasCredentials(credentials *syncer.Credentials) bool {
 	return true
 }
 
-func (s *Syncer) UpdateInstance(context.Context, int) error {
-	return nil
+func (s *Syncer) UpdateInstance(_ context.Context, desiredProcessingUnits int) (int, error) {
+	return desiredProcessingUnits, nil
 }

--- a/internal/syncer/integration_test.go
+++ b/internal/syncer/integration_test.go
@@ -1,0 +1,361 @@
+package syncer
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	monitoringpb "cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
+	instancepb "cloud.google.com/go/spanner/admin/instance/apiv1/instancepb"
+	"github.com/go-logr/logr"
+	dto "github.com/prometheus/client_model/go"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/apimachinery/pkg/types"
+	testingclock "k8s.io/utils/clock/testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/mercari/spanner-autoscaler/internal/metrics"
+	"github.com/mercari/spanner-autoscaler/internal/monitoringemulator"
+	"github.com/mercari/spanner-autoscaler/internal/observability"
+	"github.com/mercari/spanner-autoscaler/internal/spanner"
+	"github.com/mercari/spanner-autoscaler/internal/spanneremulator"
+)
+
+// integrationFixture wires the Spanner and Cloud Monitoring emulators behind
+// localhost gRPC listeners and exposes their stores so each test can configure
+// quotas, instances, and (optionally) Monitoring failure injection without
+// reaching into the emulators' internals.
+type integrationFixture struct {
+	spannerSrv         *spanneremulator.Server
+	quotaStore         *monitoringemulator.QuotaStore
+	quotaModeStore     *monitoringemulator.QuotaModeStore
+	spannerEndpoint    string
+	monitoringEndpoint string
+	registry           *prometheus.Registry
+}
+
+func newIntegrationFixture(t *testing.T) *integrationFixture {
+	t.Helper()
+
+	spannerSrv := spanneremulator.NewServer()
+	spannerLis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen spanner: %v", err)
+	}
+	spannerGrpc := grpc.NewServer()
+	instancepb.RegisterInstanceAdminServer(spannerGrpc, spannerSrv)
+	go func() { _ = spannerGrpc.Serve(spannerLis) }()
+
+	staticStore := monitoringemulator.NewStaticStore()
+	workloadStore := monitoringemulator.NewWorkloadStore()
+	scenarioStore := monitoringemulator.NewScenarioStore()
+	quotaStore := monitoringemulator.NewQuotaStore()
+	quotaModeStore := monitoringemulator.NewQuotaModeStore()
+	monitoringSrv := monitoringemulator.NewMetricServiceServer(staticStore, workloadStore, scenarioStore, quotaStore, quotaModeStore, nil)
+	monLis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		spannerGrpc.GracefulStop()
+		t.Fatalf("listen monitoring: %v", err)
+	}
+	monGrpc := grpc.NewServer()
+	monitoringpb.RegisterMetricServiceServer(monGrpc, monitoringSrv)
+	go func() { _ = monGrpc.Serve(monLis) }()
+
+	t.Cleanup(func() {
+		spannerGrpc.GracefulStop()
+		monGrpc.GracefulStop()
+	})
+
+	registry := prometheus.NewRegistry()
+	if err := observability.Register(registry); err != nil {
+		t.Fatalf("observability.Register: %v", err)
+	}
+
+	return &integrationFixture{
+		spannerSrv:         spannerSrv,
+		quotaStore:         quotaStore,
+		quotaModeStore:     quotaModeStore,
+		spannerEndpoint:    spannerLis.Addr().String(),
+		monitoringEndpoint: monLis.Addr().String(),
+		registry:           registry,
+	}
+}
+
+// makeSyncer builds a syncer that talks to the fixture's emulators. Each call
+// registers a DeleteSeries cleanup so per-test metric state is discarded.
+func (f *integrationFixture) makeSyncer(t *testing.T, projectID, instanceID, name string) (*syncer, observability.Labels) {
+	t.Helper()
+	ctx := context.Background()
+	spClient, err := spanner.NewClient(ctx, projectID, instanceID, spanner.WithEndpoint(f.spannerEndpoint))
+	if err != nil {
+		t.Fatalf("spanner.NewClient: %v", err)
+	}
+	metricsClient, err := metrics.NewClient(ctx, projectID, instanceID, metrics.WithEndpoint(f.monitoringEndpoint))
+	if err != nil {
+		t.Fatalf("metrics.NewClient: %v", err)
+	}
+	nn := types.NamespacedName{Namespace: "ns", Name: name}
+	s := &syncer{
+		spannerClient:  spClient,
+		metricsClient:  metricsClient,
+		namespacedName: nn,
+		projectID:      projectID,
+		instanceID:     instanceID,
+		log:            logr.Discard(),
+		clock:          testingclock.NewFakeClock(time.Now()),
+	}
+	labels := observability.LabelsFor(nn, projectID, instanceID)
+	t.Cleanup(func() { observability.DeleteSeries(labels) })
+	return s, labels
+}
+
+// counterValue returns the current value of the named counter whose label set
+// matches every key/value in want. Missing series read as 0, so a caller that
+// expects "exactly 1" will see "0 → fail" if the Record* path was never taken.
+func counterValue(t *testing.T, reg *prometheus.Registry, name string, want map[string]string) float64 {
+	t.Helper()
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, fam := range families {
+		if fam.GetName() != name {
+			continue
+		}
+		for _, m := range fam.GetMetric() {
+			if labelsMatch(m.GetLabel(), want) {
+				return m.GetCounter().GetValue()
+			}
+		}
+	}
+	return 0
+}
+
+func labelsMatch(got []*dto.LabelPair, want map[string]string) bool {
+	pairs := make(map[string]string, len(got))
+	for _, lp := range got {
+		pairs[lp.GetName()] = lp.GetValue()
+	}
+	for k, v := range want {
+		if pairs[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func instanceName(projectID, instanceID string) string {
+	return fmt.Sprintf("projects/%s/instances/%s", projectID, instanceID)
+}
+
+func configName(projectID, configID string) string {
+	return fmt.Sprintf("projects/%s/instanceConfigs/%s", projectID, configID)
+}
+
+// TestIntegration_RegionalFallbackSuccess matches the design's regional
+// fallback example: limit 100 nodes, usage 1 node, current 100 PU on this
+// instance, requested 101000 PU → fallback to 100000 PU. Verifies that:
+//   - applied PU is the fallback value (not the requested one)
+//   - the Spanner emulator now holds 100000 PU
+//   - the four metrics called out in the design each increment by 1
+func TestIntegration_RegionalFallbackSuccess(t *testing.T) {
+	f := newIntegrationFixture(t)
+
+	const projectID, instanceID = "ip-regional", "inst-regional"
+	const configID = "regional-asia-northeast1"
+	f.spannerSrv.AdminUpsertInstance(instanceName(projectID, instanceID), 100, configName(projectID, configID))
+	f.spannerSrv.AdminSetQuota(projectID, configID, 100000)
+	f.quotaStore.Set(projectID, "asia-northeast1", monitoringemulator.QuotaEntry{
+		QuotaMetric: "spanner.googleapis.com/nodes",
+		LimitName:   "SpannerNodesPerProject",
+		LimitNodes:  100,
+		UsageNodes:  1,
+	})
+
+	s, labels := f.makeSyncer(t, projectID, instanceID, "regional")
+	applied, err := s.UpdateInstance(context.Background(), 101000)
+	if err != nil {
+		t.Fatalf("UpdateInstance: %v", err)
+	}
+	if applied != 100000 {
+		t.Errorf("applied = %d, want 100000", applied)
+	}
+
+	inst, err := s.spannerClient.GetInstance(context.Background())
+	if err != nil {
+		t.Fatalf("GetInstance after fallback: %v", err)
+	}
+	if inst.ProcessingUnits != 100000 {
+		t.Errorf("instance ProcessingUnits = %d, want 100000", inst.ProcessingUnits)
+	}
+
+	wantIdentity := identityLabels(labels)
+	if got := counterValue(t, f.registry, "spanner_autoscaler_instance_update_errors_total", merge(wantIdentity, map[string]string{"grpc_code": "resource_exhausted"})); got != 1 {
+		t.Errorf("instance_update_errors_total{grpc_code=resource_exhausted} = %v, want 1", got)
+	}
+	if got := counterValue(t, f.registry, "spanner_autoscaler_instance_update_total", merge(wantIdentity, map[string]string{"result": "error"})); got != 1 {
+		t.Errorf("instance_update_total{result=error} = %v, want 1", got)
+	}
+	if got := counterValue(t, f.registry, "spanner_autoscaler_instance_update_total", merge(wantIdentity, map[string]string{"result": "success"})); got != 1 {
+		t.Errorf("instance_update_total{result=success} (fallback retry) = %v, want 1", got)
+	}
+	if got := counterValue(t, f.registry, "spanner_autoscaler_quota_lookup_total", merge(wantIdentity, map[string]string{"result": "success", "reason": "ok"})); got != 1 {
+		t.Errorf("quota_lookup_total{result=success,reason=ok} = %v, want 1", got)
+	}
+}
+
+// TestIntegration_MultiRegionFallbackSuccess covers the design's multi-region
+// case where the config id is the bare base config (e.g. "nam6") and the
+// matching quota metric is "spanner.googleapis.com/nodes_<config>". The
+// location label is taken from whatever Monitoring returns (here "global"),
+// not pre-derived from the config id.
+func TestIntegration_MultiRegionFallbackSuccess(t *testing.T) {
+	f := newIntegrationFixture(t)
+
+	const projectID, instanceID = "ip-nam6", "inst-nam6"
+	const configID = "nam6"
+	f.spannerSrv.AdminUpsertInstance(instanceName(projectID, instanceID), 100, configName(projectID, configID))
+	f.spannerSrv.AdminSetQuota(projectID, configID, 100000)
+	f.quotaStore.Set(projectID, "global", monitoringemulator.QuotaEntry{
+		QuotaMetric: "spanner.googleapis.com/nodes_nam6",
+		LimitName:   "SpannerNodesPerNam6",
+		LimitNodes:  100,
+		UsageNodes:  1,
+	})
+
+	s, _ := f.makeSyncer(t, projectID, instanceID, "nam6")
+	applied, err := s.UpdateInstance(context.Background(), 101000)
+	if err != nil {
+		t.Fatalf("UpdateInstance: %v", err)
+	}
+	if applied != 100000 {
+		t.Errorf("applied = %d, want 100000", applied)
+	}
+}
+
+// TestIntegration_DualRegionFallbackSuccess covers dual-region config ids
+// whose hyphens get normalized to underscores in the candidate quota metric
+// (dual-region-japan1 → spanner.googleapis.com/nodes_dual_region_japan1).
+func TestIntegration_DualRegionFallbackSuccess(t *testing.T) {
+	f := newIntegrationFixture(t)
+
+	const projectID, instanceID = "ip-dual", "inst-dual"
+	const configID = "dual-region-japan1"
+	f.spannerSrv.AdminUpsertInstance(instanceName(projectID, instanceID), 100, configName(projectID, configID))
+	f.spannerSrv.AdminSetQuota(projectID, configID, 100000)
+	f.quotaStore.Set(projectID, "global", monitoringemulator.QuotaEntry{
+		QuotaMetric: "spanner.googleapis.com/nodes_dual_region_japan1",
+		LimitName:   "SpannerNodesPerDualRegionJapan1",
+		LimitNodes:  100,
+		UsageNodes:  1,
+	})
+
+	s, _ := f.makeSyncer(t, projectID, instanceID, "dual")
+	applied, err := s.UpdateInstance(context.Background(), 101000)
+	if err != nil {
+		t.Fatalf("UpdateInstance: %v", err)
+	}
+	if applied != 100000 {
+		t.Errorf("applied = %d, want 100000", applied)
+	}
+}
+
+// TestIntegration_UnsupportedCustomConfig confirms that a "custom-*" config
+// short-circuits the Monitoring lookup: the syncer records
+// quota_lookup_total{result=skipped,reason=unsupported_instance_config},
+// does not retry, and surfaces the original ResourceExhausted to the caller.
+func TestIntegration_UnsupportedCustomConfig(t *testing.T) {
+	f := newIntegrationFixture(t)
+
+	const projectID, instanceID = "ip-custom", "inst-custom"
+	const configID = "custom-foo"
+	f.spannerSrv.AdminUpsertInstance(instanceName(projectID, instanceID), 100, configName(projectID, configID))
+	f.spannerSrv.AdminSetQuota(projectID, configID, 100000)
+
+	s, labels := f.makeSyncer(t, projectID, instanceID, "custom")
+	applied, err := s.UpdateInstance(context.Background(), 101000)
+	if status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("UpdateInstance err code = %v, want ResourceExhausted; err=%v", status.Code(err), err)
+	}
+	if applied != 0 {
+		t.Errorf("applied = %d, want 0 (no retry)", applied)
+	}
+
+	inst, err := s.spannerClient.GetInstance(context.Background())
+	if err != nil {
+		t.Fatalf("GetInstance after failure: %v", err)
+	}
+	if inst.ProcessingUnits != 100 {
+		t.Errorf("instance ProcessingUnits = %d, want 100 (unchanged)", inst.ProcessingUnits)
+	}
+
+	wantIdentity := identityLabels(labels)
+	if got := counterValue(t, f.registry, "spanner_autoscaler_quota_lookup_total", merge(wantIdentity, map[string]string{"result": "skipped", "reason": "unsupported_instance_config"})); got != 1 {
+		t.Errorf("quota_lookup_total{result=skipped,reason=unsupported_instance_config} = %v, want 1", got)
+	}
+	// No fallback retry, so the only UpdateInstance attempt is the failed one.
+	if got := counterValue(t, f.registry, "spanner_autoscaler_instance_update_total", merge(wantIdentity, map[string]string{"result": "success"})); got != 0 {
+		t.Errorf("instance_update_total{result=success} = %v, want 0", got)
+	}
+}
+
+// TestIntegration_MonitoringPermissionDenied uses the quota-mode failure
+// injection endpoint to make the Monitoring quota query return
+// PermissionDenied. The syncer must record quota_lookup_total with the
+// permission_denied reason and return the original ResourceExhausted instead
+// of swallowing it under the Monitoring error.
+func TestIntegration_MonitoringPermissionDenied(t *testing.T) {
+	f := newIntegrationFixture(t)
+
+	const projectID, instanceID = "ip-permdenied", "inst-permdenied"
+	const configID = "regional-asia-northeast1"
+	f.spannerSrv.AdminUpsertInstance(instanceName(projectID, instanceID), 100, configName(projectID, configID))
+	f.spannerSrv.AdminSetQuota(projectID, configID, 100000)
+	// Quota store is configured, but quota-mode overrides it.
+	f.quotaStore.Set(projectID, "asia-northeast1", monitoringemulator.QuotaEntry{
+		QuotaMetric: "spanner.googleapis.com/nodes",
+		LimitName:   "SpannerNodesPerProject",
+		LimitNodes:  100,
+		UsageNodes:  1,
+	})
+	f.quotaModeStore.Set(codes.PermissionDenied, "permission denied")
+
+	s, labels := f.makeSyncer(t, projectID, instanceID, "permdenied")
+	applied, err := s.UpdateInstance(context.Background(), 101000)
+	if status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("UpdateInstance err code = %v, want ResourceExhausted; err=%v", status.Code(err), err)
+	}
+	if applied != 0 {
+		t.Errorf("applied = %d, want 0 (no retry)", applied)
+	}
+
+	wantIdentity := identityLabels(labels)
+	if got := counterValue(t, f.registry, "spanner_autoscaler_quota_lookup_total", merge(wantIdentity, map[string]string{"result": "error", "reason": "permission_denied"})); got != 1 {
+		t.Errorf("quota_lookup_total{result=error,reason=permission_denied} = %v, want 1", got)
+	}
+}
+
+func identityLabels(l observability.Labels) map[string]string {
+	return map[string]string{
+		"namespace":   l.Namespace,
+		"name":        l.Name,
+		"project_id":  l.ProjectID,
+		"instance_id": l.InstanceID,
+	}
+}
+
+func merge(a, b map[string]string) map[string]string {
+	out := make(map[string]string, len(a)+len(b))
+	for k, v := range a {
+		out[k] = v
+	}
+	for k, v := range b {
+		out[k] = v
+	}
+	return out
+}

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -2,6 +2,7 @@ package syncer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"sync"
@@ -12,6 +13,8 @@ import (
 	"golang.org/x/oauth2/google"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/option"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -36,7 +39,7 @@ type Syncer interface {
 
 	// HasCredentials checks whether the existing credentials of the syncer, match the provided one or not
 	HasCredentials(credentials *Credentials) bool
-	UpdateInstance(ctx context.Context, desiredProcessingUnits int) error
+	UpdateInstance(ctx context.Context, desiredProcessingUnits int) (int, error)
 }
 
 type CredentialsType int
@@ -246,16 +249,149 @@ func (s *syncer) labels() observability.Labels {
 	return observability.LabelsFor(s.namespacedName, s.projectID, s.instanceID)
 }
 
-// UpdateInstance updates the target Spanner instance withe the desired number of processing units
-func (s *syncer) UpdateInstance(ctx context.Context, desiredProcessingUnits int) error {
+// UpdateInstance updates the target Spanner instance with the desired number of processing units.
+func (s *syncer) UpdateInstance(ctx context.Context, desiredProcessingUnits int) (int, error) {
+	err := s.updateInstanceAttempt(ctx, desiredProcessingUnits)
+	if err == nil {
+		return desiredProcessingUnits, nil
+	}
+	if status.Code(err) != codes.ResourceExhausted {
+		return 0, err
+	}
+
+	originalErr := err
+	fallbackPU, ok := s.quotaFallbackProcessingUnits(ctx, desiredProcessingUnits)
+	if !ok {
+		return 0, originalErr
+	}
+
+	err = s.updateInstanceAttempt(ctx, fallbackPU)
+	if err != nil {
+		return 0, err
+	}
+
+	return fallbackPU, nil
+}
+
+func (s *syncer) updateInstanceAttempt(ctx context.Context, desiredProcessingUnits int) error {
+	start := s.clock.Now()
 	err := s.spannerClient.UpdateInstance(ctx, &spanner.Instance{
 		ProcessingUnits: desiredProcessingUnits,
 	})
+	observability.RecordInstanceUpdate(s.labels(), s.clock.Now().Sub(start), err)
+	return err
+}
+
+func (s *syncer) quotaFallbackProcessingUnits(ctx context.Context, desiredProcessingUnits int) (int, bool) {
+	log := s.log.WithValues("desiredProcessingUnits", desiredProcessingUnits)
+
+	instance, err := s.spannerClient.GetInstance(ctx)
 	if err != nil {
-		return err
+		s.skipQuotaFallback(log, "Skipped quota fallback because Spanner instance lookup failed",
+			err, observability.QuotaLookupResultError)
+		return 0, false
 	}
 
-	return nil
+	quota, err := s.metricsClient.GetQuota(ctx, instance.Config, s.clock.Now())
+	if err != nil {
+		// Unsupported instance configurations are recorded as "skipped" rather
+		// than "error" because the lookup never actually attempted Monitoring.
+		result := observability.QuotaLookupResultError
+		msg := "Skipped quota fallback because Spanner quota lookup failed"
+		if errors.Is(err, metrics.ErrUnsupportedInstanceConfig) {
+			result = observability.QuotaLookupResultSkipped
+			msg = "Skipped quota fallback because Spanner instance configuration is unsupported"
+		}
+		s.skipQuotaFallback(log, msg, err, result,
+			"instanceConfig", instance.Config,
+			"currentProcessingUnits", instance.ProcessingUnits,
+		)
+		return 0, false
+	}
+	observability.RecordQuotaLookup(s.labels(), observability.QuotaLookupResultSuccess, observability.QuotaLookupReasonOK)
+
+	// quotaLog binds the instance + quota context so the two trailing log
+	// calls stay aligned on which fields they expose.
+	quotaLog := log.WithValues(
+		"instanceConfig", instance.Config,
+		"currentProcessingUnits", instance.ProcessingUnits,
+		"quotaLimitNodes", quota.LimitNodes,
+		"quotaUsageNodes", quota.UsageNodes,
+		"quotaMetric", quota.QuotaMetric,
+		"quotaLocation", quota.Location,
+	)
+
+	fallbackPU, ok := fallbackProcessingUnits(desiredProcessingUnits, instance.ProcessingUnits, quota)
+	if !ok {
+		quotaLog.Info("Skipped quota fallback retry")
+		return 0, false
+	}
+
+	quotaLog.Info("Retrying Spanner instance update with quota fallback",
+		"fallbackProcessingUnits", fallbackPU)
+	return fallbackPU, true
+}
+
+// skipQuotaFallback records a quota_lookup_total{result, reason} sample and
+// emits a single Info log with the error and any caller-supplied key/value
+// pairs. Centralized so the three skip branches in quotaFallbackProcessingUnits
+// stay aligned on which fields they expose.
+func (s *syncer) skipQuotaFallback(log logr.Logger, msg string, err error, result string, extra ...any) {
+	reason := quotaLookupReason(err)
+	kvs := append([]any{"error", err, "reason", reason}, extra...)
+	log.Info(msg, kvs...)
+	observability.RecordQuotaLookup(s.labels(), result, reason)
+}
+
+func fallbackProcessingUnits(desiredProcessingUnits, currentProcessingUnits int, quota *metrics.Quota) (int, bool) {
+	if quota == nil || quota.LimitNodes <= 0 || quota.UsageNodes < 0 || currentProcessingUnits <= 0 {
+		return 0, false
+	}
+
+	// Convert PU → nodes with ceil so a 100 PU target is still counted as 1 node.
+	currentTargetQuotaNodes := int64((currentProcessingUnits + 999) / 1000)
+	availableNodesForTarget := quota.LimitNodes - (quota.UsageNodes - currentTargetQuotaNodes)
+	if availableNodesForTarget <= 0 {
+		return 0, false
+	}
+
+	availablePUForTarget := int(availableNodesForTarget) * 1000
+	fallbackPU := desiredProcessingUnits
+	if fallbackPU > availablePUForTarget {
+		fallbackPU = availablePUForTarget
+	}
+	if fallbackPU <= currentProcessingUnits || fallbackPU >= desiredProcessingUnits {
+		return 0, false
+	}
+	return fallbackPU, true
+}
+
+func quotaLookupReason(err error) string {
+	switch {
+	case errors.Is(err, metrics.ErrUnsupportedInstanceConfig):
+		return observability.QuotaLookupReasonUnsupportedInstanceConfig
+	case errors.Is(err, metrics.ErrQuotaNoData):
+		return observability.QuotaLookupReasonNoData
+	case errors.Is(err, metrics.ErrQuotaMalformedResponse):
+		return observability.QuotaLookupReasonMalformedResponse
+	case errors.Is(err, context.DeadlineExceeded):
+		return observability.QuotaLookupReasonTimeout
+	}
+
+	switch status.Code(err) {
+	case codes.PermissionDenied:
+		return observability.QuotaLookupReasonPermissionDenied
+	case codes.Unauthenticated:
+		return observability.QuotaLookupReasonUnauthenticated
+	case codes.Unavailable:
+		return observability.QuotaLookupReasonUnavailable
+	case codes.ResourceExhausted:
+		return observability.QuotaLookupReasonResourceExhausted
+	case codes.DeadlineExceeded:
+		return observability.QuotaLookupReasonTimeout
+	default:
+		return observability.QuotaLookupReasonUnknown
+	}
 }
 
 func (s *syncer) syncResource(ctx context.Context) error {

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -2,6 +2,8 @@ package syncer
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -10,6 +12,8 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,6 +28,7 @@ import (
 
 	spannerv1beta1 "github.com/mercari/spanner-autoscaler/api/v1beta1"
 	"github.com/mercari/spanner-autoscaler/internal/metrics"
+	"github.com/mercari/spanner-autoscaler/internal/observability"
 	"github.com/mercari/spanner-autoscaler/internal/spanner"
 )
 
@@ -244,6 +249,273 @@ func Test_syncer_getInstanceInfo(t *testing.T) {
 
 func intPtr(i int) *int { return &i }
 
+func Test_fallbackProcessingUnits(t *testing.T) {
+	tests := []struct {
+		name      string
+		desired   int
+		current   int
+		quota     *metrics.Quota
+		want      int
+		wantRetry bool
+	}{
+		{
+			name:    "new project 100 nodes quota",
+			desired: 101000,
+			current: 100,
+			quota: &metrics.Quota{
+				LimitNodes: 100,
+				UsageNodes: 1,
+			},
+			want:      100000,
+			wantRetry: true,
+		},
+		{
+			name:    "other instances consume quota",
+			desired: 45000,
+			current: 35000,
+			quota: &metrics.Quota{
+				LimitNodes: 40,
+				UsageNodes: 38,
+			},
+			want:      37000,
+			wantRetry: true,
+		},
+		{
+			name:    "no room above current",
+			desired: 45000,
+			current: 40000,
+			quota: &metrics.Quota{
+				LimitNodes: 40,
+				UsageNodes: 40,
+			},
+			wantRetry: false,
+		},
+		{
+			name:    "quota says requested should fit",
+			desired: 40000,
+			current: 35000,
+			quota: &metrics.Quota{
+				LimitNodes: 40,
+				UsageNodes: 35,
+			},
+			wantRetry: false,
+		},
+		{
+			name:      "nil quota guards against panic",
+			desired:   45000,
+			current:   35000,
+			quota:     nil,
+			wantRetry: false,
+		},
+		{
+			name:    "limit nodes is zero",
+			desired: 45000,
+			current: 35000,
+			quota: &metrics.Quota{
+				LimitNodes: 0,
+				UsageNodes: 0,
+			},
+			wantRetry: false,
+		},
+		{
+			name:    "usage nodes is negative",
+			desired: 45000,
+			current: 35000,
+			quota: &metrics.Quota{
+				LimitNodes: 40,
+				UsageNodes: -1,
+			},
+			wantRetry: false,
+		},
+		{
+			name:    "current processing units is zero",
+			desired: 45000,
+			current: 0,
+			quota: &metrics.Quota{
+				LimitNodes: 40,
+				UsageNodes: 0,
+			},
+			wantRetry: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := fallbackProcessingUnits(tt.desired, tt.current, tt.quota)
+			if ok != tt.wantRetry {
+				t.Fatalf("fallbackProcessingUnits() retry = %t, want %t", ok, tt.wantRetry)
+			}
+			if got != tt.want {
+				t.Errorf("fallbackProcessingUnits() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// scriptedSpannerClient returns the next error in updateErrs on each
+// UpdateInstance call. A nil entry means "succeed and apply the patch".
+// GetInstance returns a fixed snapshot. Used by tests that need to drive
+// syncer.UpdateInstance through specific error sequences.
+type scriptedSpannerClient struct {
+	mu              sync.Mutex
+	config          string
+	processingUnits int
+	updateErrs      []error
+	updateCalls     []int // captured ProcessingUnits per call, in order
+}
+
+func (c *scriptedSpannerClient) GetInstance(_ context.Context) (*spanner.Instance, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return &spanner.Instance{
+		ProcessingUnits: c.processingUnits,
+		InstanceState:   spanner.StateReady,
+		Config:          c.config,
+	}, nil
+}
+
+func (c *scriptedSpannerClient) UpdateInstance(_ context.Context, instance *spanner.Instance) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.updateCalls = append(c.updateCalls, instance.ProcessingUnits)
+	if len(c.updateErrs) == 0 {
+		c.processingUnits = instance.ProcessingUnits
+		return nil
+	}
+	err := c.updateErrs[0]
+	c.updateErrs = c.updateErrs[1:]
+	if err == nil {
+		c.processingUnits = instance.ProcessingUnits
+	}
+	return err
+}
+
+// recordingQuotaMetricsClient counts GetQuota calls so tests can assert the
+// quota lookup was (or was not) invoked. Always returns a fixed Quota.
+type recordingQuotaMetricsClient struct {
+	mu         sync.Mutex
+	quotaCalls int
+	quota      *metrics.Quota
+	quotaErr   error
+}
+
+func (c *recordingQuotaMetricsClient) GetInstanceMetrics(_ context.Context, _ metrics.MetricType, _ time.Time) (*metrics.InstanceMetrics, error) {
+	return &metrics.InstanceMetrics{}, nil
+}
+
+func (c *recordingQuotaMetricsClient) GetQuota(_ context.Context, _ string, _ time.Time) (*metrics.Quota, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.quotaCalls++
+	if c.quotaErr != nil {
+		return nil, c.quotaErr
+	}
+	return c.quota, nil
+}
+
+func newSyncerForUpdate(spannerClient spanner.Client, metricsClient metrics.Client) *syncer {
+	return &syncer{
+		spannerClient:  spannerClient,
+		metricsClient:  metricsClient,
+		namespacedName: types.NamespacedName{Namespace: "ns", Name: "n"},
+		projectID:      "p",
+		instanceID:     "i",
+		log:            logr.Discard(),
+		clock:          testingclock.NewFakeClock(time.Date(2020, 4, 1, 0, 0, 0, 0, time.UTC)),
+	}
+}
+
+// Test_syncer_UpdateInstance_NonRetryableError covers the design's "失敗が
+// codes.ResourceExhausted 以外なら、従来通り error を返す。quota lookup はしない"
+// path: a PermissionDenied from UpdateInstance must short-circuit before any
+// GetQuota / fallback retry happens.
+func Test_syncer_UpdateInstance_NonRetryableError(t *testing.T) {
+	sp := &scriptedSpannerClient{
+		config:          "projects/p/instanceConfigs/regional-asia-northeast1",
+		processingUnits: 100,
+		updateErrs:      []error{status.Error(codes.PermissionDenied, "denied")},
+	}
+	mc := &recordingQuotaMetricsClient{}
+	s := newSyncerForUpdate(sp, mc)
+
+	applied, err := s.UpdateInstance(context.Background(), 1000)
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("UpdateInstance err code = %v, want PermissionDenied; err=%v", status.Code(err), err)
+	}
+	if applied != 0 {
+		t.Errorf("applied = %d, want 0", applied)
+	}
+	if mc.quotaCalls != 0 {
+		t.Errorf("GetQuota called %d times, want 0", mc.quotaCalls)
+	}
+	if got := len(sp.updateCalls); got != 1 {
+		t.Errorf("UpdateInstance attempts = %d, want 1 (no fallback)", got)
+	}
+}
+
+// Test_syncer_UpdateInstance_FallbackRetryFails covers the design's "fallback
+// 更新も失敗したら、その error を返す。再帰や複数回 retry はしない" path: the
+// retry's error (not the original ResourceExhausted) propagates to the caller,
+// and only two UpdateInstance attempts are made.
+func Test_syncer_UpdateInstance_FallbackRetryFails(t *testing.T) {
+	sp := &scriptedSpannerClient{
+		config:          "projects/p/instanceConfigs/regional-asia-northeast1",
+		processingUnits: 100,
+		updateErrs: []error{
+			status.Error(codes.ResourceExhausted, "quota"),
+			status.Error(codes.Internal, "retry failed"),
+		},
+	}
+	mc := &recordingQuotaMetricsClient{
+		quota: &metrics.Quota{LimitNodes: 100, UsageNodes: 1},
+	}
+	s := newSyncerForUpdate(sp, mc)
+
+	applied, err := s.UpdateInstance(context.Background(), 101000)
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("UpdateInstance err code = %v, want Internal (retry error); err=%v", status.Code(err), err)
+	}
+	if applied != 0 {
+		t.Errorf("applied = %d, want 0", applied)
+	}
+	if mc.quotaCalls != 1 {
+		t.Errorf("GetQuota calls = %d, want 1", mc.quotaCalls)
+	}
+	if got := len(sp.updateCalls); got != 2 {
+		t.Errorf("UpdateInstance attempts = %d, want 2 (initial + 1 retry)", got)
+	}
+	if got := sp.updateCalls[1]; got != 100000 {
+		t.Errorf("fallback retry PU = %d, want 100000", got)
+	}
+}
+
+func Test_quotaLookupReason(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"unsupported config", metrics.ErrUnsupportedInstanceConfig, observability.QuotaLookupReasonUnsupportedInstanceConfig},
+		{"no data", metrics.ErrQuotaNoData, observability.QuotaLookupReasonNoData},
+		{"malformed response", metrics.ErrQuotaMalformedResponse, observability.QuotaLookupReasonMalformedResponse},
+		{"context deadline exceeded", context.DeadlineExceeded, observability.QuotaLookupReasonTimeout},
+		{"grpc permission denied", status.Error(codes.PermissionDenied, "x"), observability.QuotaLookupReasonPermissionDenied},
+		{"grpc unauthenticated", status.Error(codes.Unauthenticated, "x"), observability.QuotaLookupReasonUnauthenticated},
+		{"grpc unavailable", status.Error(codes.Unavailable, "x"), observability.QuotaLookupReasonUnavailable},
+		{"grpc resource exhausted", status.Error(codes.ResourceExhausted, "x"), observability.QuotaLookupReasonResourceExhausted},
+		{"grpc deadline exceeded", status.Error(codes.DeadlineExceeded, "x"), observability.QuotaLookupReasonTimeout},
+		{"plain error falls through to unknown", errors.New("boom"), observability.QuotaLookupReasonUnknown},
+		{"wrapped sentinel still resolves", fmt.Errorf("outer: %w", metrics.ErrQuotaNoData), observability.QuotaLookupReasonNoData},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := quotaLookupReason(tt.err); got != tt.want {
+				t.Errorf("quotaLookupReason(%v) = %q, want %q", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
 // recordingMetricsClient is a metrics.Client that records the now value each
 // GetInstanceMetrics call received, keyed by MetricType. Used to verify that
 // dual-mode metric queries share a single base time.
@@ -265,6 +537,10 @@ func (c *recordingMetricsClient) GetInstanceMetrics(_ context.Context, metricTyp
 	default:
 		return &metrics.InstanceMetrics{CurrentHighPriorityCPUUtilization: 20}, nil
 	}
+}
+
+func (c *recordingMetricsClient) GetQuota(_ context.Context, _ string, _ time.Time) (*metrics.Quota, error) {
+	return nil, metrics.ErrQuotaNoData
 }
 
 func Test_syncer_getInstanceInfoDual_sharesBaseTime(t *testing.T) {

--- a/internal/webhook/v1beta1/spannerautoscaler_webhook.go
+++ b/internal/webhook/v1beta1/spannerautoscaler_webhook.go
@@ -194,23 +194,8 @@ func validateScaleConfig(r *spannerv1beta1.SpannerAutoscaler) *field.Error {
 		}
 	}
 
-	if sc.ProcessingUnits != (spannerv1beta1.ScaleConfigPUs{}) {
-		if sc.ProcessingUnits.Max < sc.ProcessingUnits.Min {
-			return field.Invalid(
-				field.NewPath("spec").Child("scaleConfig").Child("processingUnits").Child("max"),
-				sc.Nodes.Max,
-				"'max' value must be less than 'min' value")
-		}
-		if err := validateProcessingUnits(
-			sc.ProcessingUnits.Min,
-			field.NewPath("spec").Child("scaleConfig").Child("processingUnits").Child("min")); err != nil {
-			return err
-		}
-		if err := validateProcessingUnits(
-			sc.ProcessingUnits.Max,
-			field.NewPath("spec").Child("scaleConfig").Child("processingUnits").Child("max")); err != nil {
-			return err
-		}
+	if err := validateProcessingUnitRange(sc); err != nil {
+		return err
 	}
 
 	switch sc.ScaledownStepSize.Type {
@@ -299,7 +284,45 @@ func validateScaleConfig(r *spannerv1beta1.SpannerAutoscaler) *field.Error {
 	return nil
 }
 
+func validateProcessingUnitRange(sc spannerv1beta1.ScaleConfig) *field.Error {
+	if sc.ProcessingUnits == (spannerv1beta1.ScaleConfigPUs{}) {
+		return nil
+	}
+
+	if sc.ProcessingUnits.Max < sc.ProcessingUnits.Min {
+		return field.Invalid(
+			field.NewPath("spec").Child("scaleConfig").Child("processingUnits").Child("max"),
+			sc.ProcessingUnits.Max,
+			"'max' value must be less than 'min' value")
+	}
+	if err := validateProcessingUnits(
+		sc.ProcessingUnits.Min,
+		field.NewPath("spec").Child("scaleConfig").Child("processingUnits").Child("min")); err != nil {
+		return err
+	}
+	if err := validateProcessingUnits(
+		sc.ProcessingUnits.Max,
+		field.NewPath("spec").Child("scaleConfig").Child("processingUnits").Child("max")); err != nil {
+		return err
+	}
+	return nil
+}
+
 func validateProcessingUnits(pu int, fldPath *field.Path) *field.Error {
+	if pu < 100 {
+		return field.Invalid(
+			fldPath,
+			pu,
+			"processing units must be at least 100")
+	}
+
+	if pu < 1000 && pu%100 != 0 {
+		return field.Invalid(
+			fldPath,
+			pu,
+			"processing units which are less than 1000, should be multiples of 100")
+	}
+
 	if pu >= 1000 && pu%1000 != 0 {
 		return field.Invalid(
 			fldPath,


### PR DESCRIPTION
## Summary

When Spanner `UpdateInstance` returns `codes.ResourceExhausted`, the syncer now
looks up the project's node quota from Cloud Monitoring (`quota/limit` +
`quota/allocation/usage`) and retries once with the largest PU value that fits
the observed quota. The lookup is best-effort: any error or unsupported
configuration is recorded via `spanner_autoscaler_quota_lookup_total` and the
original `ResourceExhausted` is surfaced to the caller — the fallback never
masks the underlying failure.

This PR is implemented without CRD changes. Spanner quota is read from Cloud
Monitoring at the moment of the failure, not from spec, so a stale or missing
quota cap cannot silently allow over-application against a tighter real quota.

### Behavior

- `syncer.UpdateInstance` now returns `(appliedPU int, error)` so the controller
  can distinguish what was requested from what actually landed.
- `Status.DesiredProcessingUnits` stays at the calculated value even after a
  fallback clamp, so dashboards see the gap to `CurrentProcessingUnits` when
  quota throttles scale-up.
- Each `UpdateInstance` attempt — both the initial one and the fallback retry —
  is recorded independently in `instance_update_total` and
  `instance_update_errors_total{grpc_code}`, so the failure mode is observable
  even when the retry succeeds.

### New Prometheus metrics

| Name | Type | Labels | Description |
|---|---|---|---|
| `spanner_autoscaler_instance_update_errors_total` | Counter | `grpc_code` | Failed `UpdateInstance` calls bucketed by gRPC code (`resource_exhausted`, `permission_denied`, `unknown`, …). |
| `spanner_autoscaler_quota_lookup_total` | Counter | `result`, `reason` | Outcome of the Cloud Monitoring quota lookup triggered by a `ResourceExhausted`. `result` is `success` / `error` / `skipped`; `reason` covers `ok`, `permission_denied`, `unauthenticated`, `unavailable`, `resource_exhausted`, `timeout`, `no_data`, `malformed_response`, `unsupported_instance_config`, `unknown`. |

### Instance configurations covered

- **Regional** (`regional-<region>`): quota_metric `spanner.googleapis.com/nodes`, location pre-derived from the config id, `limit_name=SpannerNodesPerProject`.
- **Multi-region / dual-region**: quota_metric synthesized from the config id with `-` → `_` (`nam6` → `nodes_nam6`, `dual-region-japan1` → `nodes_dual_region_japan1`), location adopted from the Monitoring response (typically `global`).
- **Custom** (`custom-*`) and unknown bases: skipped before any Monitoring round-trip, original `ResourceExhausted` returned.

### Emulator additions

- **`internal/spanneremulator`**: configurable per-(project, config_id) PU quota that returns `ResourceExhausted` when the aggregate across instances sharing the config would exceed it; `PUT /instances/{p}/{i}` now accepts a `config` field so test instances can be placed in any instance configuration.
- **`internal/monitoringemulator`**: serves both `serviceruntime.googleapis.com/quota/limit` and `…/quota/allocation/usage` for any configured project/location; a separate `PUT /quota-mode` endpoint forces every quota query to fail with a configurable gRPC code, so the controller's Monitoring-failure degrade path is testable end-to-end against the emulator.

### Drive-by fixes

- **Tiltfile / docs**: `--cert-dir` was renamed to `--webhook-cert-path` by the kubebuilder v4 migration (#246); the Tiltfile and one docs line still referenced the old flag and the controller exited immediately under `tilt up`.
- **Webhook**: tighten processing-unit validation to also reject values below 100 / non-multiples of 100 (under 1000), and report the correct field value when `processingUnits.max < min`.
- **Spanner client**: drop the pre-flight `GetInstance` inside `UpdateInstance` — `FieldMask=[\"processing_units\"]` makes it unnecessary, and it doubled the GetInstance count on the fallback path.

## Test plan

- [x] `go test ./internal/...` — added unit coverage for the new resolver, fallback math edge cases (nil quota / limit=0 / usage<0 / current=0), `quotaLookupReason` mappings (9 reasons + wrapped sentinel + plain error), non-RE short-circuit, fallback-retry-fails error propagation, `grpcCodeFor` non-gRPC error, emulator quota aggregation across instances and across configs, and the monitoring emulator `/quota-mode` HTTP handler.
- [x] End-to-end integration test (`internal/syncer/integration_test.go`) drives `syncer.UpdateInstance` through real gRPC connections to the in-process emulators across five scenarios: regional success (with metric increment assertions), multi-region (`nam6`), dual-region (`dual-region-japan1`), unsupported custom config, and PermissionDenied injection.
- [x] Manual verification with `make tilt-up` + the local sample, against the running emulators in a kind cluster:
  - baseline scaling (`scenarios/default.yaml` cycle) — unchanged behavior
  - `no_data` degrade: Spanner quota set, Monitoring absent → original RE returned, `reason=no_data`
  - regional fallback success: `fallbackProcessingUnits=4000` computed, `currentProcessingUnits` reaches 4000, `Status.DesiredProcessingUnits` still reflects the calculated 7000
  - fallback retry failing under tighter real Spanner quota — retry error propagated, no silent over-apply
  - multi-region (`nam6`): correct quota_metric synthesis, location discovered from Monitoring response
  - unsupported custom config: skipped before Monitoring round-trip
  - `PUT /quota-mode` injects PermissionDenied → controller logs `reason=permission_denied`, original RE returned
- [x] `gofmt -l .` clean, `golangci-lint run ./internal/... ./cmd/monitoring-emulator/...` 0 issues
- [x] `make generate` / `make docs` no-ops (no API type changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)