### PR TITLE
docs: clarify that scheduled scaling can exceed spec max processing units

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ spec:
 
 The `cron` field supports extended syntax (`L`, `L-n`, `nW`, `LW`, `DAY#n`, `DAY#L`) in addition to the standard 5-field format, powered by [go-cron](https://github.com/netresearch/go-cron). See the [Extended Syntax documentation](https://pkg.go.dev/github.com/netresearch/go-cron#hdr-Extended_Syntax__Optional_) for details and examples.
 
+> **Note:** While a schedule is active, `additionalProcessingUnits` is added to **both ends** of the autoscaling range: the effective range becomes `[spec.processingUnits.min + additionalProcessingUnits, spec.processingUnits.max + additionalProcessingUnits]` (exposed as `status.desiredMinPUs` / `status.desiredMaxPUs`). This means the instance can be scaled **beyond `spec.processingUnits.max`** — with `max: 1000` and the schedule above, the instance may reach 1,600 PU while the schedule is active. Because the lower bound is raised as well, the instance is scaled up to at least `min + additionalProcessingUnits` even when CPU utilization is low. Once the schedule's window (`duration`) ends, the range reverts to the values in `spec`, and the instance scales back down after the configured scale-down interval.
+
 > **Note:** When multiple schedules are active simultaneously (i.e. their windows overlap), the `additionalProcessingUnits` from all active schedules are **summed** and added to both `desiredMinPUs` and `desiredMaxPUs`. For example, if schedule A adds +1,000 PU and schedule B adds +5,000 PU and both are active at the same time, `desiredMinPUs = spec.processingUnits.min + 6,000`.
 
 ### Scale down time restrictions

--- a/api/v1beta1/spannerautoscaleschedule_types.go
+++ b/api/v1beta1/spannerautoscaleschedule_types.go
@@ -38,6 +38,9 @@ type SpannerAutoscaleScheduleSpec struct {
 	TargetResource string `json:"targetResource"`
 
 	// The extra compute capacity which will be added when this schedule is active.
+	// While active, this value is added to both the minimum and maximum of the target
+	// SpannerAutoscaler's autoscaling range, so the instance can be scaled beyond
+	// `spec.scaleConfig.processingUnits.max` by this amount.
 	AdditionalProcessingUnits int `json:"additionalProcessingUnits"`
 
 	// The details of when and for how long this schedule will be active.

--- a/config/crd/bases/spanner.mercari.com_spannerautoscaleschedules.yaml
+++ b/config/crd/bases/spanner.mercari.com_spannerautoscaleschedules.yaml
@@ -52,8 +52,11 @@ spec:
               SpannerAutoscaleSchedule
             properties:
               additionalProcessingUnits:
-                description: The extra compute capacity which will be added when this
-                  schedule is active.
+                description: |-
+                  The extra compute capacity which will be added when this schedule is active.
+                  While active, this value is added to both the minimum and maximum of the target
+                  SpannerAutoscaler's autoscaling range, so the instance can be scaled beyond
+                  `spec.scaleConfig.processingUnits.max` by this amount.
                 type: integer
               schedule:
                 description: The details of when and for how long this schedule will

--- a/config/crd/bases/spanner.mercari.com_spannermanualscalings.yaml
+++ b/config/crd/bases/spanner.mercari.com_spannermanualscalings.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: spannermanualscalings.spanner.mercari.com
 spec:
   group: spanner.mercari.com
@@ -64,14 +64,25 @@ spec:
               scaledownAllowedTimes / scaledownNotAllowedTimes windows for as long as it
               is active.
 
-              Pacing is inferred from the presence of the step-size field for the required
-              direction:
+              The target may be above or below the current processing units. The
+              controller picks the direction from the sign of
+              (ProcessingUnits - CurrentProcessingUnits) and reads only the step-size /
+              interval fields for that direction. Pacing is inferred from the presence
+              of the step-size field:
 
-                - ScaleupStepSize unset (when target > current)  → single-jump scale-up.
-                - ScaleupStepSize set    (when target > current) → stepped ramp; the
-                  cadence comes from ScaleupInterval when set, otherwise from the
+                - target > current, ScaleupStepSize unset      → single-jump scale-up.
+                - target > current, ScaleupStepSize set        → stepped scale-up ramp;
+                  the cadence comes from ScaleupInterval when set, otherwise from the
                   controller's --scale-up-interval flag default.
-                - ScaledownStepSize / ScaledownInterval behave symmetrically.
+                - target < current, ScaledownStepSize unset    → single-jump scale-down.
+                - target < current, ScaledownStepSize set      → stepped scale-down ramp;
+                  the cadence comes from ScaledownInterval when set, otherwise from the
+                  controller's --scale-down-interval flag default.
+
+              Manual scale-down is accepted by default. Cluster operators who want to
+              forbid it can run the controller with --reject-manual-scaledown=true; in
+              that mode an override whose target is below the current PU lands in the
+              Invalid phase rather than scaling the instance down.
 
               Interval-only specification (e.g. ScaleupInterval set but ScaleupStepSize
               unset) has no effect; the validating webhook emits an admission warning to
@@ -106,8 +117,11 @@ spec:
               processingUnits:
                 description: |-
                   ProcessingUnits is the target value that this override drives toward
-                  while active. Must be a multiple of 100 (for values < 1000) or a
-                  multiple of 1000.
+                  while active. May be above or below the autoscaler's current PU; the
+                  controller derives the scaling direction from the sign of
+                  (ProcessingUnits - CurrentProcessingUnits) and consults the matching
+                  step-size / interval fields below. Must be a multiple of 100 (for
+                  values < 1000) or a multiple of 1000.
                 minimum: 100
                 type: integer
               scaledownInterval:

--- a/docs/crd-reference.md
+++ b/docs/crd-reference.md
@@ -297,7 +297,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `targetResource` _string_ | The `SpannerAutoscaler` resource name with which this schedule will be registered.<br />Immutable after creation. |  |  |
-| `additionalProcessingUnits` _integer_ | The extra compute capacity which will be added when this schedule is active. |  |  |
+| `additionalProcessingUnits` _integer_ | The extra compute capacity which will be added when this schedule is active.<br />While active, this value is added to both the minimum and maximum of the target<br />SpannerAutoscaler's autoscaling range, so the instance can be scaled beyond<br />`spec.scaleConfig.processingUnits.max` by this amount. |  |  |
 | `schedule` _[Schedule](#schedule)_ | The details of when and for how long this schedule will be active. |  |  |
 
 


### PR DESCRIPTION
## Why

`SpannerAutoscaleSchedule` documentation explained that `additionalProcessingUnits` "bumps up the scaling range", but never stated the key operational fact: **while a schedule is active, the instance can be scaled beyond `spec.scaleConfig.processingUnits.max`** by the `additionalProcessingUnits` amount. Operators who assumed `spec.processingUnits.max` is an absolute ceiling have read PU values above it as a controller bug (e.g. `max: 60000` + `additionalProcessingUnits: 20000` scaling to 80000 PU).

The behavior itself is intended: `calcDesiredPURange` adds the additional PU to both ends of the range, so the effective range during the window is `[min + additionalPU, max + additionalPU]`, and it reverts when the window ends. This PR documents that explicitly.

## What

- **README** (Scheduled scaling feature): add a note spelling out the effective range, that it exceeds `spec.processingUnits.max`, that the raised lower bound forces a scale-up even at low CPU, and that the range reverts after `duration` ends.
- **`AdditionalProcessingUnits` godoc** (`api/v1beta1/spannerautoscaleschedule_types.go`): same clarification, so `kubectl explain`, the CRD schema description, and `docs/crd-reference.md` all carry it. Regenerated manifests and CRD reference accordingly.
- **`chore` commit**: `config/crd/bases/spanner.mercari.com_spannermanualscalings.yaml` had drifted from the current godoc (#242) and controller-tools version (#248); regenerated so this branch starts from clean generator output.

## Notes

Documentation-only change; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)