### PR TITLE
feat: add maxPUPolicy to SpannerAutoscaleSchedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ spec:
     duration: 3h
 ```
 
-- `Exceed` (default): raises both ends of the range, so the instance may scale beyond `spec.processingUnits.max`. This is the original behavior and remains the default for backward compatibility. The CRD schema default is applied by the API server when objects are served, so schedules created before this field existed are also read and displayed as `Exceed`.
+- `Exceed` (default): raises both ends of the range, so the instance may scale beyond `spec.processingUnits.max`. This is the original behavior and remains the default for backward compatibility. Schedules created before this field existed may have an empty value; the controller treats empty/unset as `Exceed` everywhere for backward compatibility.
 - `Cap`: raises only the lower bound; `spec.processingUnits.max` remains the hard ceiling. If `min + additionalProcessingUnits` exceeds `max`, the lower bound is clamped down to `max` (the effective range never inverts), the trimmed contribution is logged, and a `ScheduleCappedAtMax` event is emitted on the `SpannerAutoscaler`.
 
 > **Note:** When multiple schedules are active simultaneously (i.e. their windows overlap), the `additionalProcessingUnits` from all active schedules are **summed**: every active schedule contributes to `desiredMinPUs`, while only schedules with `maxPUPolicy: Exceed` (or unset) contribute to `desiredMaxPUs`. For example, if schedule A adds +1,000 PU and schedule B adds +5,000 PU and both are active at the same time, `desiredMinPUs = spec.processingUnits.min + 6,000`.

--- a/README.md
+++ b/README.md
@@ -45,9 +45,26 @@ spec:
 
 The `cron` field supports extended syntax (`L`, `L-n`, `nW`, `LW`, `DAY#n`, `DAY#L`) in addition to the standard 5-field format, powered by [go-cron](https://github.com/netresearch/go-cron). See the [Extended Syntax documentation](https://pkg.go.dev/github.com/netresearch/go-cron#hdr-Extended_Syntax__Optional_) for details and examples.
 
-> **Note:** While a schedule is active, `additionalProcessingUnits` is added to **both ends** of the autoscaling range: the effective range becomes `[spec.processingUnits.min + additionalProcessingUnits, spec.processingUnits.max + additionalProcessingUnits]` (exposed as `status.desiredMinPUs` / `status.desiredMaxPUs`). This means the instance can be scaled **beyond `spec.processingUnits.max`** — with `max: 1000` and the schedule above, the instance may reach 1,600 PU while the schedule is active. Because the lower bound is raised as well, the instance is scaled up to at least `min + additionalProcessingUnits` even when CPU utilization is low. Once the schedule's window (`duration`) ends, the range reverts to the values in `spec`, and the instance scales back down after the configured scale-down interval.
+#### Interaction with the autoscaling range (`maxPUPolicy`)
 
-> **Note:** When multiple schedules are active simultaneously (i.e. their windows overlap), the `additionalProcessingUnits` from all active schedules are **summed** and added to both `desiredMinPUs` and `desiredMaxPUs`. For example, if schedule A adds +1,000 PU and schedule B adds +5,000 PU and both are active at the same time, `desiredMinPUs = spec.processingUnits.min + 6,000`.
+While a schedule is active, `additionalProcessingUnits` is by default added to **both ends** of the autoscaling range: the effective range becomes `[spec.processingUnits.min + additionalProcessingUnits, spec.processingUnits.max + additionalProcessingUnits]` (exposed as `status.desiredMinPUs` / `status.desiredMaxPUs`). This means the instance can be scaled **beyond `spec.processingUnits.max`** — with `max: 1000` and the schedule above, the instance may reach 1,600 PU while the schedule is active. Because the lower bound is raised as well, the instance is scaled up to at least `min + additionalProcessingUnits` even when CPU utilization is low. Once the schedule's window (`duration`) ends, the range reverts to the values in `spec`, and the instance scales back down after the configured scale-down interval.
+
+The `maxPUPolicy` field controls whether the schedule may exceed the max:
+
+```yaml
+spec:
+  targetResource: spannerautoscaler-sample
+  additionalProcessingUnits: 600
+  maxPUPolicy: Cap   # Exceed (default) | Cap
+  schedule:
+    cron: "0 2 * * *"
+    duration: 3h
+```
+
+- `Exceed` (default): raises both ends of the range, so the instance may scale beyond `spec.processingUnits.max`. This is the original behavior and remains the default for backward compatibility. Schedules created before the field existed show an empty `MAX PU POLICY` column in `kubectl get spannerautoscaleschedules`, which is treated as `Exceed`.
+- `Cap`: raises only the lower bound; `spec.processingUnits.max` remains the hard ceiling. If `min + additionalProcessingUnits` exceeds `max`, the lower bound is clamped down to `max` (the effective range never inverts), the trimmed contribution is logged, and a `ScheduleCappedAtMax` event is emitted on the `SpannerAutoscaler`.
+
+> **Note:** When multiple schedules are active simultaneously (i.e. their windows overlap), the `additionalProcessingUnits` from all active schedules are **summed**: every active schedule contributes to `desiredMinPUs`, while only schedules with `maxPUPolicy: Exceed` (or unset) contribute to `desiredMaxPUs`. For example, if schedule A adds +1,000 PU and schedule B adds +5,000 PU and both are active at the same time, `desiredMinPUs = spec.processingUnits.min + 6,000`.
 
 ### Scale down time restrictions
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ spec:
     duration: 3h
 ```
 
-- `Exceed` (default): raises both ends of the range, so the instance may scale beyond `spec.processingUnits.max`. This is the original behavior and remains the default for backward compatibility. Schedules created before the field existed show an empty `MAX PU POLICY` column in `kubectl get spannerautoscaleschedules`, which is treated as `Exceed`.
+- `Exceed` (default): raises both ends of the range, so the instance may scale beyond `spec.processingUnits.max`. This is the original behavior and remains the default for backward compatibility. The CRD schema default is applied by the API server when objects are served, so schedules created before this field existed are also read and displayed as `Exceed`.
 - `Cap`: raises only the lower bound; `spec.processingUnits.max` remains the hard ceiling. If `min + additionalProcessingUnits` exceeds `max`, the lower bound is clamped down to `max` (the effective range never inverts), the trimmed contribution is logged, and a `ScheduleCappedAtMax` event is emitted on the `SpannerAutoscaler`.
 
 > **Note:** When multiple schedules are active simultaneously (i.e. their windows overlap), the `additionalProcessingUnits` from all active schedules are **summed**: every active schedule contributes to `desiredMinPUs`, while only schedules with `maxPUPolicy: Exceed` (or unset) contribute to `desiredMaxPUs`. For example, if schedule A adds +1,000 PU and schedule B adds +5,000 PU and both are active at the same time, `desiredMinPUs = spec.processingUnits.min + 6,000`.

--- a/api/v1beta1/spannerautoscaler_types.go
+++ b/api/v1beta1/spannerautoscaler_types.go
@@ -275,6 +275,11 @@ type ActiveSchedule struct {
 
 	// The extra compute capacity which will be added because of this schedule
 	AdditionalPU int `json:"additionalPU"`
+
+	// How this schedule interacts with the autoscaler's max processing units.
+	// Empty is treated as `Exceed` (entries written by older controllers).
+	// +optional
+	MaxPUPolicy MaxPUPolicy `json:"maxPUPolicy,omitempty"`
 }
 
 // A `SpannerManualScaling` which is currently overriding this autoscaler's

--- a/api/v1beta1/spannerautoscaleschedule_types.go
+++ b/api/v1beta1/spannerautoscaleschedule_types.go
@@ -31,6 +31,33 @@ type Schedule struct {
 	Duration string `json:"duration"`
 }
 
+// MaxPUPolicy defines how additionalProcessingUnits interacts with the
+// target SpannerAutoscaler's max processing units.
+// +kubebuilder:validation:Enum=Exceed;Cap
+type MaxPUPolicy string
+
+const (
+	// MaxPUPolicyExceed raises both ends of the autoscaling range, allowing
+	// the instance to scale beyond `spec.scaleConfig.processingUnits.max`
+	// (current behavior; default).
+	MaxPUPolicyExceed MaxPUPolicy = "Exceed"
+
+	// MaxPUPolicyCap raises only the lower bound of the autoscaling range.
+	// `spec.scaleConfig.processingUnits.max` remains the hard ceiling.
+	MaxPUPolicyCap MaxPUPolicy = "Cap"
+)
+
+// Normalized resolves the empty value to the MaxPUPolicyExceed default.
+// Specs and status entries written before this field existed (or by older
+// controllers) carry an empty policy; every consumer must treat them as
+// Exceed, and this method is the single place that rule lives.
+func (p MaxPUPolicy) Normalized() MaxPUPolicy {
+	if p == "" {
+		return MaxPUPolicyExceed
+	}
+	return p
+}
+
 // SpannerAutoscaleScheduleSpec defines the desired state of SpannerAutoscaleSchedule
 type SpannerAutoscaleScheduleSpec struct {
 	// The `SpannerAutoscaler` resource name with which this schedule will be registered.
@@ -38,10 +65,19 @@ type SpannerAutoscaleScheduleSpec struct {
 	TargetResource string `json:"targetResource"`
 
 	// The extra compute capacity which will be added when this schedule is active.
-	// While active, this value is added to both the minimum and maximum of the target
-	// SpannerAutoscaler's autoscaling range, so the instance can be scaled beyond
+	// While active, this value is added to the minimum — and, unless maxPUPolicy is
+	// `Cap`, also the maximum — of the target SpannerAutoscaler's autoscaling range,
+	// so by default the instance can be scaled beyond
 	// `spec.scaleConfig.processingUnits.max` by this amount.
 	AdditionalProcessingUnits int `json:"additionalProcessingUnits"`
+
+	// How additionalProcessingUnits interacts with the target SpannerAutoscaler's
+	// `spec.scaleConfig.processingUnits.max`. `Exceed` (default) raises both ends
+	// of the autoscaling range, so the instance may scale beyond max.
+	// `Cap` raises only the lower bound and never exceeds max.
+	// +kubebuilder:default=Exceed
+	// +optional
+	MaxPUPolicy MaxPUPolicy `json:"maxPUPolicy,omitempty"`
 
 	// The details of when and for how long this schedule will be active.
 	Schedule Schedule `json:"schedule"`
@@ -56,6 +92,7 @@ type SpannerAutoscaleScheduleStatus struct{}
 // +kubebuilder:printcolumn:name="Cron",type="string",JSONPath=".spec.schedule.cron"
 // +kubebuilder:printcolumn:name="Duration",type="string",JSONPath=".spec.schedule.duration"
 // +kubebuilder:printcolumn:name="Additional PU",type="integer",JSONPath=".spec.additionalProcessingUnits"
+// +kubebuilder:printcolumn:name="Max PU Policy",type="string",JSONPath=".spec.maxPUPolicy"
 // SpannerAutoscaleSchedule is the Schema for the spannerautoscaleschedules API
 type SpannerAutoscaleSchedule struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/config/crd/bases/spanner.mercari.com_spannerautoscalers.yaml
+++ b/config/crd/bases/spanner.mercari.com_spannerautoscalers.yaml
@@ -552,6 +552,14 @@ spec:
                       description: The time until when this schedule will remain active
                       format: date-time
                       type: string
+                    maxPUPolicy:
+                      description: |-
+                        How this schedule interacts with the autoscaler's max processing units.
+                        Empty is treated as `Exceed` (entries written by older controllers).
+                      enum:
+                      - Exceed
+                      - Cap
+                      type: string
                     name:
                       description: Name of the `SpannerAutoscaleSchedule`
                       type: string

--- a/config/crd/bases/spanner.mercari.com_spannerautoscaleschedules.yaml
+++ b/config/crd/bases/spanner.mercari.com_spannerautoscaleschedules.yaml
@@ -24,6 +24,9 @@ spec:
     - jsonPath: .spec.additionalProcessingUnits
       name: Additional PU
       type: integer
+    - jsonPath: .spec.maxPUPolicy
+      name: Max PU Policy
+      type: string
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -54,10 +57,22 @@ spec:
               additionalProcessingUnits:
                 description: |-
                   The extra compute capacity which will be added when this schedule is active.
-                  While active, this value is added to both the minimum and maximum of the target
-                  SpannerAutoscaler's autoscaling range, so the instance can be scaled beyond
+                  While active, this value is added to the minimum — and, unless maxPUPolicy is
+                  `Cap`, also the maximum — of the target SpannerAutoscaler's autoscaling range,
+                  so by default the instance can be scaled beyond
                   `spec.scaleConfig.processingUnits.max` by this amount.
                 type: integer
+              maxPUPolicy:
+                default: Exceed
+                description: |-
+                  How additionalProcessingUnits interacts with the target SpannerAutoscaler's
+                  `spec.scaleConfig.processingUnits.max`. `Exceed` (default) raises both ends
+                  of the autoscaling range, so the instance may scale beyond max.
+                  `Cap` raises only the lower bound and never exceeds max.
+                enum:
+                - Exceed
+                - Cap
+                type: string
               schedule:
                 description: The details of when and for how long this schedule will
                   be active.

--- a/docs/crd-reference.md
+++ b/docs/crd-reference.md
@@ -54,6 +54,7 @@ _Appears in:_
 | `name` _string_ | Name of the `SpannerAutoscaleSchedule` |  |  |
 | `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#time-v1-meta)_ | The time until when this schedule will remain active |  |  |
 | `additionalPU` _integer_ | The extra compute capacity which will be added because of this schedule |  |  |
+| `maxPUPolicy` _[MaxPUPolicy](#maxpupolicy)_ | How this schedule interacts with the autoscaler's max processing units.<br />Empty is treated as `Exceed` (entries written by older controllers). |  | Enum: [Exceed Cap] <br />Optional: \{\} <br /> |
 
 
 #### AuthType
@@ -188,6 +189,26 @@ _Appears in:_
 
 
 
+#### MaxPUPolicy
+
+_Underlying type:_ _string_
+
+MaxPUPolicy defines how additionalProcessingUnits interacts with the
+target SpannerAutoscaler's max processing units.
+
+_Validation:_
+- Enum: [Exceed Cap]
+
+_Appears in:_
+- [ActiveSchedule](#activeschedule)
+- [SpannerAutoscaleScheduleSpec](#spannerautoscaleschedulespec)
+
+| Field | Description |
+| --- | --- |
+| `Exceed` | MaxPUPolicyExceed raises both ends of the autoscaling range, allowing<br />the instance to scale beyond `spec.scaleConfig.processingUnits.max`<br />(current behavior; default).<br /> |
+| `Cap` | MaxPUPolicyCap raises only the lower bound of the autoscaling range.<br />`spec.scaleConfig.processingUnits.max` remains the hard ceiling.<br /> |
+
+
 #### ScaleConfig
 
 
@@ -297,7 +318,8 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `targetResource` _string_ | The `SpannerAutoscaler` resource name with which this schedule will be registered.<br />Immutable after creation. |  |  |
-| `additionalProcessingUnits` _integer_ | The extra compute capacity which will be added when this schedule is active.<br />While active, this value is added to both the minimum and maximum of the target<br />SpannerAutoscaler's autoscaling range, so the instance can be scaled beyond<br />`spec.scaleConfig.processingUnits.max` by this amount. |  |  |
+| `additionalProcessingUnits` _integer_ | The extra compute capacity which will be added when this schedule is active.<br />While active, this value is added to the minimum — and, unless maxPUPolicy is<br />`Cap`, also the maximum — of the target SpannerAutoscaler's autoscaling range,<br />so by default the instance can be scaled beyond<br />`spec.scaleConfig.processingUnits.max` by this amount. |  |  |
+| `maxPUPolicy` _[MaxPUPolicy](#maxpupolicy)_ | How additionalProcessingUnits interacts with the target SpannerAutoscaler's<br />`spec.scaleConfig.processingUnits.max`. `Exceed` (default) raises both ends<br />of the autoscaling range, so the instance may scale beyond max.<br />`Cap` raises only the lower bound and never exceeds max. | Exceed | Enum: [Exceed Cap] <br />Optional: \{\} <br /> |
 | `schedule` _[Schedule](#schedule)_ | The details of when and for how long this schedule will be active. |  |  |
 
 

--- a/internal/controller/spannerautoscaler_controller.go
+++ b/internal/controller/spannerautoscaler_controller.go
@@ -467,10 +467,27 @@ func (r *SpannerAutoscalerReconciler) Reconcile(ctx context.Context, req ctrlrec
 		return result, err
 	}
 
-	if minPU, maxPU, updated := calcDesiredPURange(sa); updated {
+	if minPU, maxPU, updated, capped := calcDesiredPURange(sa); updated {
 		sa.Status.DesiredMinPUs = minPU
 		sa.Status.DesiredMaxPUs = maxPU
 		statusChanged = true
+
+		// Surface trimmed Cap contributions once per range transition
+		// (updated guards re-emission on every reconcile while the same
+		// capped range stays in effect). Without this, part of a Cap
+		// schedule's additionalProcessingUnits being silently dropped is
+		// indistinguishable from the schedule not firing at all.
+		if capped {
+			log.Info("scheduled scaling capped at max processing units",
+				"desiredMinPUs", minPU,
+				"desiredMaxPUs", maxPU,
+				"specMinPUs", sa.Spec.ScaleConfig.ProcessingUnits.Min,
+				"specMaxPUs", sa.Spec.ScaleConfig.ProcessingUnits.Max,
+			)
+			r.recorder.Eventf(&sa, corev1.EventTypeNormal, "ScheduleCappedAtMax",
+				"active schedule(s) with maxPUPolicy=Cap raised the lower bound above the upper bound; clamped range to [%d, %d]",
+				minPU, maxPU)
+		}
 	}
 
 	desiredProcessingUnits := calcDesiredProcessingUnits(sa)
@@ -490,11 +507,13 @@ func (r *SpannerAutoscalerReconciler) Reconcile(ctx context.Context, req ctrlrec
 		// CurrentlyActiveSchedules contains only schedules whose cron has fired
 		// and whose EndTime has not yet passed (not every configured schedule).
 		// Overlapping active schedules stack additively — this mirrors how
-		// calcDesiredPURange folds AdditionalPU into the min/max PU range.
+		// calcDesiredPURange folds AdditionalPU into the min/max PU range
+		// (every schedule raises the min; only maxPUPolicy=Exceed raises the max).
 		activeScheduleNames := make([]string, 0, len(sa.Status.CurrentlyActiveSchedules))
 		var scheduleAdditionalPU int
 		for _, as := range sa.Status.CurrentlyActiveSchedules {
-			activeScheduleNames = append(activeScheduleNames, as.ScheduleName)
+			activeScheduleNames = append(activeScheduleNames,
+				fmt.Sprintf("%s (%s)", as.ScheduleName, as.MaxPUPolicy.Normalized()))
 			scheduleAdditionalPU += as.AdditionalPU
 		}
 		log.V(1).Info("processing units need to be changed",
@@ -1020,16 +1039,31 @@ func scaleDriver(sa *spannerv1beta1.SpannerAutoscaler, after int) string {
 	}
 }
 
-func calcDesiredPURange(sa spannerv1beta1.SpannerAutoscaler) (int, int, bool) {
-	changed := false
-	var desiredMin, desiredMax int
+// calcDesiredPURange computes the effective autoscaling range from the spec
+// range and the currently active schedules. Every active schedule raises the
+// lower bound by its AdditionalPU; whether it also raises the upper bound
+// depends on its MaxPUPolicy: Exceed extends the max beyond
+// spec.processingUnits.max, Cap keeps the spec max as the hard ceiling. An
+// empty policy is treated as Exceed for backward compatibility with entries
+// written by older controllers.
+//
+// The returned range always satisfies desiredMin <= desiredMax: the min is
+// clamped down to the max after rounding (rounding first, so the 1000-unit
+// round-up cannot push the min back above the max). capped reports whether
+// this clamp trimmed part of the Cap schedules' contribution, so the caller
+// can surface the reduction to operators.
+func calcDesiredPURange(sa spannerv1beta1.SpannerAutoscaler) (minPU, maxPU int, changed, capped bool) {
+	// Start from the spec range; active schedules only ever add to it.
+	// A Cap schedule skips the max addition, so the max never drops below
+	// spec.processingUnits.max.
+	desiredMin := sa.Spec.ScaleConfig.ProcessingUnits.Min
+	desiredMax := sa.Spec.ScaleConfig.ProcessingUnits.Max
 	for _, sched := range sa.Status.CurrentlyActiveSchedules {
 		desiredMin += sched.AdditionalPU
-		desiredMax += sched.AdditionalPU
+		if sched.MaxPUPolicy.Normalized() == spannerv1beta1.MaxPUPolicyExceed {
+			desiredMax += sched.AdditionalPU
+		}
 	}
-
-	desiredMin += sa.Spec.ScaleConfig.ProcessingUnits.Min
-	desiredMax += sa.Spec.ScaleConfig.ProcessingUnits.Max
 
 	// round up, in case any schedule adds small number of PUs
 	if remainder := desiredMin % 1000; desiredMin > 1000 && remainder != 0 {
@@ -1040,11 +1074,18 @@ func calcDesiredPURange(sa spannerv1beta1.SpannerAutoscaler) (int, int, bool) {
 		desiredMax = ((desiredMax / 1000) + 1) * 1000
 	}
 
+	// Cap schedules do not extend the max, so the summed min can exceed it.
+	// Never publish an inverted range: clamp the min down to the max.
+	if desiredMin > desiredMax {
+		desiredMin = desiredMax
+		capped = true
+	}
+
 	if desiredMin != sa.Status.DesiredMinPUs || desiredMax != sa.Status.DesiredMaxPUs {
 		changed = true
 	}
 
-	return desiredMin, desiredMax, changed
+	return desiredMin, desiredMax, changed, capped
 }
 
 func (r *SpannerAutoscalerReconciler) fetchCredentials(ctx context.Context, sa *spannerv1beta1.SpannerAutoscaler) (*syncerpkg.Credentials, error) {

--- a/internal/controller/spannerautoscaler_controller_test.go
+++ b/internal/controller/spannerautoscaler_controller_test.go
@@ -649,10 +649,11 @@ var _ = Describe("Calculate Desired PU Range", func() {
 		sa := baseSpec(1000, 10000)
 		sa.Status.DesiredMinPUs = 1000
 		sa.Status.DesiredMaxPUs = 10000
-		gotMin, gotMax, changed := calcDesiredPURange(sa)
+		gotMin, gotMax, changed, capped := calcDesiredPURange(sa)
 		Expect(gotMin).To(Equal(1000))
 		Expect(gotMax).To(Equal(10000))
 		Expect(changed).To(BeFalse())
+		Expect(capped).To(BeFalse())
 	})
 
 	It("adds AdditionalPU to spec min/max for a single active schedule", func() {
@@ -660,10 +661,11 @@ var _ = Describe("Calculate Desired PU Range", func() {
 		sa.Status.CurrentlyActiveSchedules = []spannerv1beta1.ActiveSchedule{
 			{AdditionalPU: 2000},
 		}
-		gotMin, gotMax, changed := calcDesiredPURange(sa)
+		gotMin, gotMax, changed, capped := calcDesiredPURange(sa)
 		Expect(gotMin).To(Equal(3000))
 		Expect(gotMax).To(Equal(12000))
 		Expect(changed).To(BeTrue())
+		Expect(capped).To(BeFalse())
 	})
 
 	It("sums AdditionalPU from all active schedules for both min and max", func() {
@@ -672,7 +674,7 @@ var _ = Describe("Calculate Desired PU Range", func() {
 			{AdditionalPU: 1000},
 			{AdditionalPU: 5000},
 		}
-		gotMin, gotMax, changed := calcDesiredPURange(sa)
+		gotMin, gotMax, changed, _ := calcDesiredPURange(sa)
 		// desiredMin = 1000 + (1000 + 5000) = 7000
 		// desiredMax = 10000 + (1000 + 5000) = 16000
 		Expect(gotMin).To(Equal(7000))
@@ -685,7 +687,7 @@ var _ = Describe("Calculate Desired PU Range", func() {
 		sa.Status.CurrentlyActiveSchedules = []spannerv1beta1.ActiveSchedule{
 			{AdditionalPU: 1500},
 		}
-		gotMin, gotMax, changed := calcDesiredPURange(sa)
+		gotMin, gotMax, changed, _ := calcDesiredPURange(sa)
 		// desiredMin = 1000 + 1500 = 2500 → rounded up to 3000
 		// desiredMax = 10000 + 1500 = 11500 → rounded up to 12000
 		Expect(gotMin).To(Equal(3000))
@@ -698,7 +700,7 @@ var _ = Describe("Calculate Desired PU Range", func() {
 		sa.Status.CurrentlyActiveSchedules = []spannerv1beta1.ActiveSchedule{
 			{AdditionalPU: 3000},
 		}
-		gotMin, gotMax, changed := calcDesiredPURange(sa)
+		gotMin, gotMax, changed, _ := calcDesiredPURange(sa)
 		Expect(gotMin).To(Equal(4000))
 		Expect(gotMax).To(Equal(13000))
 		Expect(changed).To(BeTrue())
@@ -711,8 +713,74 @@ var _ = Describe("Calculate Desired PU Range", func() {
 		}
 		sa.Status.DesiredMinPUs = 3000
 		sa.Status.DesiredMaxPUs = 12000
-		_, _, changed := calcDesiredPURange(sa)
+		_, _, changed, _ := calcDesiredPURange(sa)
 		Expect(changed).To(BeFalse())
+	})
+
+	It("treats an explicit Exceed policy the same as an empty policy", func() {
+		sa := baseSpec(1000, 10000)
+		sa.Status.CurrentlyActiveSchedules = []spannerv1beta1.ActiveSchedule{
+			{AdditionalPU: 2000, MaxPUPolicy: spannerv1beta1.MaxPUPolicyExceed},
+		}
+		gotMin, gotMax, changed, capped := calcDesiredPURange(sa)
+		Expect(gotMin).To(Equal(3000))
+		Expect(gotMax).To(Equal(12000))
+		Expect(changed).To(BeTrue())
+		Expect(capped).To(BeFalse())
+	})
+
+	It("does not raise the max for a Cap schedule", func() {
+		sa := baseSpec(1000, 10000)
+		sa.Status.CurrentlyActiveSchedules = []spannerv1beta1.ActiveSchedule{
+			{AdditionalPU: 2000, MaxPUPolicy: spannerv1beta1.MaxPUPolicyCap},
+		}
+		gotMin, gotMax, changed, capped := calcDesiredPURange(sa)
+		// desiredMin = 1000 + 2000 = 3000; desiredMax stays at spec max.
+		Expect(gotMin).To(Equal(3000))
+		Expect(gotMax).To(Equal(10000))
+		Expect(changed).To(BeTrue())
+		Expect(capped).To(BeFalse())
+	})
+
+	It("clamps desiredMin to desiredMax when a Cap schedule raises min above max", func() {
+		sa := baseSpec(50000, 60000)
+		sa.Status.CurrentlyActiveSchedules = []spannerv1beta1.ActiveSchedule{
+			{AdditionalPU: 20000, MaxPUPolicy: spannerv1beta1.MaxPUPolicyCap},
+		}
+		gotMin, gotMax, changed, capped := calcDesiredPURange(sa)
+		// desiredMin = 50000 + 20000 = 70000 → clamped to max 60000.
+		Expect(gotMin).To(Equal(60000))
+		Expect(gotMax).To(Equal(60000))
+		Expect(changed).To(BeTrue())
+		Expect(capped).To(BeTrue())
+	})
+
+	It("clamps after rounding so the round-up cannot push min back above max", func() {
+		sa := baseSpec(1000, 10000)
+		sa.Status.CurrentlyActiveSchedules = []spannerv1beta1.ActiveSchedule{
+			{AdditionalPU: 9500, MaxPUPolicy: spannerv1beta1.MaxPUPolicyCap},
+		}
+		gotMin, gotMax, changed, capped := calcDesiredPURange(sa)
+		// desiredMin = 1000 + 9500 = 10500 → rounded up to 11000 → clamped to 10000.
+		Expect(gotMin).To(Equal(10000))
+		Expect(gotMax).To(Equal(10000))
+		Expect(changed).To(BeTrue())
+		Expect(capped).To(BeTrue())
+	})
+
+	It("mixes Exceed and Cap schedules: only Exceed extends the max", func() {
+		sa := baseSpec(1000, 10000)
+		sa.Status.CurrentlyActiveSchedules = []spannerv1beta1.ActiveSchedule{
+			{AdditionalPU: 20000, MaxPUPolicy: spannerv1beta1.MaxPUPolicyExceed},
+			{AdditionalPU: 10000, MaxPUPolicy: spannerv1beta1.MaxPUPolicyCap},
+		}
+		gotMin, gotMax, changed, capped := calcDesiredPURange(sa)
+		// desiredMin = 1000 + 30000 = 31000
+		// desiredMax = 10000 + 20000 = 30000 → min clamped to 30000.
+		Expect(gotMin).To(Equal(30000))
+		Expect(gotMax).To(Equal(30000))
+		Expect(changed).To(BeTrue())
+		Expect(capped).To(BeTrue())
 	})
 })
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -176,6 +176,10 @@ func (j Job) Run() {
 			ScheduleName: j.ScheduleName.String(),
 			AdditionalPU: sas.Spec.AdditionalProcessingUnits,
 			EndTime:      metav1.Time{Time: metav1.Now().Add(duration)},
+			// Normalized so status entries are always explicit; readers
+			// still normalize on their side for entries written by older
+			// controllers.
+			MaxPUPolicy: sas.Spec.MaxPUPolicy.Normalized(),
 		}
 		j.Log.V(1).Info("updating active schedules", "now", metav1.Now(), "endtime", metav1.Now().Add(duration))
 
@@ -191,6 +195,7 @@ func (j Job) Run() {
 	} else {
 		j.Log.Info("scheduled scaling activated",
 			"additionalPU", cas.AdditionalPU,
+			"maxPUPolicy", cas.MaxPUPolicy,
 			"endTime", cas.EndTime.Time,
 			"duration", sas.Spec.Schedule.Duration,
 		)

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1,0 +1,86 @@
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	spannerv1beta1 "github.com/mercari/spanner-autoscaler/api/v1beta1"
+)
+
+// TestJobRun_PropagatesMaxPUPolicy verifies that Job.Run copies the
+// schedule's maxPUPolicy onto the ActiveSchedule status entry, normalizing
+// an unset policy to the Exceed default.
+func TestJobRun_PropagatesMaxPUPolicy(t *testing.T) {
+	tests := []struct {
+		name       string
+		specPolicy spannerv1beta1.MaxPUPolicy
+		wantPolicy spannerv1beta1.MaxPUPolicy
+	}{
+		{name: "empty policy is normalized to Exceed", specPolicy: "", wantPolicy: spannerv1beta1.MaxPUPolicyExceed},
+		{name: "Exceed is propagated as-is", specPolicy: spannerv1beta1.MaxPUPolicyExceed, wantPolicy: spannerv1beta1.MaxPUPolicyExceed},
+		{name: "Cap is propagated as-is", specPolicy: spannerv1beta1.MaxPUPolicyCap, wantPolicy: spannerv1beta1.MaxPUPolicyCap},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			if err := spannerv1beta1.AddToScheme(scheme); err != nil {
+				t.Fatalf("failed to add scheme: %v", err)
+			}
+
+			schedNN := types.NamespacedName{Namespace: "default", Name: "test-schedule"}
+			saNN := types.NamespacedName{Namespace: "default", Name: "test-sa"}
+
+			sched := &spannerv1beta1.SpannerAutoscaleSchedule{
+				ObjectMeta: metav1.ObjectMeta{Namespace: schedNN.Namespace, Name: schedNN.Name},
+				Spec: spannerv1beta1.SpannerAutoscaleScheduleSpec{
+					TargetResource:            saNN.Name,
+					AdditionalProcessingUnits: 2000,
+					MaxPUPolicy:               tt.specPolicy,
+					Schedule: spannerv1beta1.Schedule{
+						Cron:     "* * * * *",
+						Duration: "1h",
+					},
+				},
+			}
+			sa := &spannerv1beta1.SpannerAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{Namespace: saNN.Namespace, Name: saNN.Name},
+			}
+
+			fc := fakeclient.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(sched, sa).
+				WithStatusSubresource(&spannerv1beta1.SpannerAutoscaler{}).
+				Build()
+
+			job := Job{
+				ScheduleName:   schedNN,
+				AutoscalerName: saNN,
+				Cron:           sched.Spec.Schedule.Cron,
+				Log:            logr.Discard(),
+				CtrlClient:     fc,
+			}
+			job.Run()
+
+			var got spannerv1beta1.SpannerAutoscaler
+			if err := fc.Get(t.Context(), saNN, &got); err != nil {
+				t.Fatalf("failed to get autoscaler: %v", err)
+			}
+			if len(got.Status.CurrentlyActiveSchedules) != 1 {
+				t.Fatalf("expected 1 active schedule, got %d", len(got.Status.CurrentlyActiveSchedules))
+			}
+			as := got.Status.CurrentlyActiveSchedules[0]
+			if as.MaxPUPolicy != tt.wantPolicy {
+				t.Errorf("MaxPUPolicy = %q, want %q", as.MaxPUPolicy, tt.wantPolicy)
+			}
+			if as.AdditionalPU != 2000 {
+				t.Errorf("AdditionalPU = %d, want 2000", as.AdditionalPU)
+			}
+		})
+	}
+}

--- a/test/integration/schedule_maxpupolicy_test.go
+++ b/test/integration/schedule_maxpupolicy_test.go
@@ -1,0 +1,258 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	k8sscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	spannerv1alpha1 "github.com/mercari/spanner-autoscaler/api/v1alpha1"
+	spannerv1beta1 "github.com/mercari/spanner-autoscaler/api/v1beta1"
+	"github.com/mercari/spanner-autoscaler/internal/controller"
+)
+
+// TestController_E2E_ScheduleMaxPUPolicyCap verifies that a schedule with
+// maxPUPolicy: Cap raises only the lower bound of the autoscaling range:
+// under sustained CPU pressure that always wants more capacity, the instance
+// must never be scaled beyond spec.processingUnits.max even while the
+// schedule is active.
+func TestController_E2E_ScheduleMaxPUPolicyCap(t *testing.T) {
+	const (
+		projectID         = "cappolicy-project"
+		instanceID        = "cappolicy-instance"
+		initPU            = 60000
+		minPU             = 1000
+		maxPU             = 60000
+		additionalPU      = 20000
+		syncInterval      = 1 * time.Second
+		scaleUpInterval   = 1 * time.Second
+		scaleDownInterval = 55 * time.Minute
+		activateWithin    = 90 * time.Second
+		observeFor        = 90 * time.Second
+	)
+	targetCPUVal := 40
+	targetCPU := &targetCPUVal
+	skipValidation := true
+
+	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	// Sustained heavy workload: cpu = 72000/PU, i.e. 120% at 60000 PU — the
+	// CPU-driven calculation always wants more than max, so only the upper
+	// bound decides how far the controller scales.
+	body, _ := json.Marshal(map[string]interface{}{
+		"high_priority": map[string]interface{}{
+			"cpu_utilization":            0.90,
+			"reference_processing_units": 80000,
+		},
+	})
+	adminPUT(t, fmt.Sprintf("/workload/%s/%s", projectID, instanceID), body)
+	t.Cleanup(func() { adminDELETE(t, fmt.Sprintf("/workload/%s/%s", projectID, instanceID)) })
+
+	createSpannerInstance(t, projectID, instanceID, initPU)
+
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join(repoRoot(), "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+	cfg, err := testEnv.Start()
+	if err != nil {
+		t.Fatalf("failed to start envtest: %v", err)
+	}
+	t.Cleanup(func() { testEnv.Stop() }) //nolint:errcheck
+
+	if err := spannerv1alpha1.AddToScheme(k8sscheme.Scheme); err != nil {
+		t.Fatalf("add v1alpha1 scheme: %v", err)
+	}
+	if err := spannerv1beta1.AddToScheme(k8sscheme.Scheme); err != nil {
+		t.Fatalf("add v1beta1 scheme: %v", err)
+	}
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:     k8sscheme.Scheme,
+		Metrics:    metricsserver.Options{BindAddress: "0"},
+		Controller: ctrlconfig.Controller{SkipNameValidation: &skipValidation},
+	})
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	reconciler := controller.NewSpannerAutoscalerReconciler(
+		mgr.GetClient(),
+		mgr.GetAPIReader(),
+		mgr.GetScheme(),
+		mgr.GetEventRecorderFor("cappolicy-controller"),
+		logf.Log.WithName("cappolicy"),
+		controller.WithSpannerEndpoint(spannerEmulatorAddr()),
+		controller.WithMetricsEndpoint(monitoringGRPCAddr()),
+		controller.WithSyncInterval(syncInterval),
+		controller.WithScaleUpInterval(scaleUpInterval),
+		controller.WithScaleDownInterval(scaleDownInterval),
+	)
+	if err := reconciler.SetupWithManager(mgr); err != nil {
+		t.Fatalf("failed to setup controller: %v", err)
+	}
+
+	scheduleReconciler := controller.NewSpannerAutoscaleScheduleReconciler(
+		mgr.GetClient(),
+		mgr.GetScheme(),
+		mgr.GetEventRecorderFor("cappolicy-schedule-controller"),
+	)
+	if err := scheduleReconciler.SetupWithManager(mgr); err != nil {
+		t.Fatalf("failed to setup schedule controller: %v", err)
+	}
+
+	mgrCtx, mgrCancel := context.WithCancel(context.Background())
+	t.Cleanup(mgrCancel)
+	t.Cleanup(reconciler.StopAll)
+	go func() {
+		if err := mgr.Start(mgrCtx); err != nil {
+			t.Logf("manager exited: %v", err)
+		}
+	}()
+
+	k8sClient := mgr.GetClient()
+	ctx := context.Background()
+	nn := types.NamespacedName{Namespace: "default", Name: "cappolicy-sa"}
+
+	sa := &spannerv1beta1.SpannerAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nn.Name,
+			Namespace: nn.Namespace,
+		},
+		Spec: spannerv1beta1.SpannerAutoscalerSpec{
+			TargetInstance: spannerv1beta1.TargetInstance{
+				ProjectID:  projectID,
+				InstanceID: instanceID,
+			},
+			Authentication: spannerv1beta1.Authentication{
+				Type: spannerv1beta1.AuthTypeADC,
+			},
+			ScaleConfig: spannerv1beta1.ScaleConfig{
+				ComputeType: spannerv1beta1.ComputeTypePU,
+				ProcessingUnits: spannerv1beta1.ScaleConfigPUs{
+					Min: minPU,
+					Max: maxPU,
+				},
+				ScaledownStepSize: intstr.FromInt(2000),
+				TargetCPUUtilization: spannerv1beta1.TargetCPUUtilization{
+					HighPriority: targetCPU,
+				},
+			},
+		},
+	}
+	if err := k8sClient.Create(ctx, sa); err != nil {
+		t.Fatalf("failed to create SpannerAutoscaler: %v", err)
+	}
+
+	sched := &spannerv1beta1.SpannerAutoscaleSchedule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cappolicy-schedule",
+			Namespace: nn.Namespace,
+		},
+		Spec: spannerv1beta1.SpannerAutoscaleScheduleSpec{
+			TargetResource:            nn.Name,
+			AdditionalProcessingUnits: additionalPU,
+			MaxPUPolicy:               spannerv1beta1.MaxPUPolicyCap,
+			Schedule: spannerv1beta1.Schedule{
+				Cron:     "* * * * *",
+				Duration: "5m",
+			},
+		},
+	}
+	if err := k8sClient.Create(ctx, sched); err != nil {
+		t.Fatalf("failed to create SpannerAutoscaleSchedule: %v", err)
+	}
+
+	// Phase 1: wait until the schedule's cron fires and the ActiveSchedule
+	// entry lands in status, so the "never exceeds max" assertion below is
+	// exercised with the schedule actually in effect.
+	activated := false
+	deadline := time.Now().Add(activateWithin)
+	for time.Now().Before(deadline) {
+		var cur spannerv1beta1.SpannerAutoscaler
+		if err := k8sClient.Get(ctx, nn, &cur); err == nil && len(cur.Status.CurrentlyActiveSchedules) > 0 {
+			as := cur.Status.CurrentlyActiveSchedules[0]
+			t.Logf("schedule activated: additionalPU=%d maxPUPolicy=%q", as.AdditionalPU, as.MaxPUPolicy)
+			if as.MaxPUPolicy != spannerv1beta1.MaxPUPolicyCap {
+				t.Errorf("ActiveSchedule.MaxPUPolicy = %q, want %q", as.MaxPUPolicy, spannerv1beta1.MaxPUPolicyCap)
+			}
+			activated = true
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	if !activated {
+		t.Fatalf("schedule did not activate within %s", activateWithin)
+	}
+
+	// Phase 2: with the Cap schedule active and CPU pressure sustained,
+	// the instance must stay at spec max; the lower bound must reflect the
+	// schedule (min + additionalPU) and the upper bound must not move.
+	var (
+		maxSeenCurrent int
+		maxSeenDesired int
+		maxSeenRange   int
+		lastLogged     string
+	)
+	wantDesiredMin := minPU + additionalPU // 21000, well below max: no clamping expected here
+	deadline = time.Now().Add(observeFor)
+	for time.Now().Before(deadline) {
+		var cur spannerv1beta1.SpannerAutoscaler
+		if err := k8sClient.Get(ctx, nn, &cur); err != nil {
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+		if cur.Status.CurrentProcessingUnits > maxSeenCurrent {
+			maxSeenCurrent = cur.Status.CurrentProcessingUnits
+		}
+		if cur.Status.DesiredProcessingUnits > maxSeenDesired {
+			maxSeenDesired = cur.Status.DesiredProcessingUnits
+		}
+		if cur.Status.DesiredMaxPUs > maxSeenRange {
+			maxSeenRange = cur.Status.DesiredMaxPUs
+		}
+		if len(cur.Status.CurrentlyActiveSchedules) > 0 && cur.Status.DesiredMinPUs != wantDesiredMin {
+			t.Errorf("desiredMinPUs = %d, want %d while Cap schedule is active", cur.Status.DesiredMinPUs, wantDesiredMin)
+		}
+		snapshot := fmt.Sprintf("currentPU=%d desiredPU=%d desiredMinPUs=%d desiredMaxPUs=%d activeSchedules=%d",
+			cur.Status.CurrentProcessingUnits,
+			cur.Status.DesiredProcessingUnits,
+			cur.Status.DesiredMinPUs,
+			cur.Status.DesiredMaxPUs,
+			len(cur.Status.CurrentlyActiveSchedules))
+		if snapshot != lastLogged {
+			t.Logf("%s %s", time.Now().Format("15:04:05"), snapshot)
+			lastLogged = snapshot
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	t.Logf("observed maxima: currentPU=%d desiredPU=%d desiredMaxPUs=%d (spec max %d)",
+		maxSeenCurrent, maxSeenDesired, maxSeenRange, maxPU)
+
+	if maxSeenCurrent > maxPU {
+		t.Errorf("instance PU exceeded spec max with maxPUPolicy=Cap: got %d, max %d", maxSeenCurrent, maxPU)
+	}
+	if maxSeenDesired > maxPU {
+		t.Errorf("desired PU exceeded spec max with maxPUPolicy=Cap: got %d, max %d", maxSeenDesired, maxPU)
+	}
+	if maxSeenRange > maxPU {
+		t.Errorf("status.desiredMaxPUs exceeded spec max with maxPUPolicy=Cap: got %d, max %d", maxSeenRange, maxPU)
+	}
+}


### PR DESCRIPTION
## Why

While a `SpannerAutoscaleSchedule` is active, `additionalProcessingUnits` is added to **both ends** of the autoscaling range, so the instance can scale beyond `spec.scaleConfig.processingUnits.max` (documented in #250). Some operators treat `max` as a hard cost/quota ceiling and want schedules to guarantee extra capacity **without ever crossing it**. This PR makes that choice configurable per schedule.

## What

Add `spec.maxPUPolicy` (enum) to `SpannerAutoscaleSchedule`:

```yaml
spec:
  targetResource: spannerautoscaler-sample
  additionalProcessingUnits: 600
  maxPUPolicy: Cap   # Exceed (default) | Cap
  schedule:
    cron: "0 2 * * *"
    duration: 3h
```

- **`Exceed` (default)** — raises both ends of the range; the instance may scale beyond `spec.processingUnits.max`. This is the existing behavior and stays the default for backward compatibility. An empty policy (resources and status entries written before this field existed) is treated as `Exceed` everywhere, centralized in `MaxPUPolicy.Normalized()`.
- **`Cap`** — raises only the lower bound; `spec.processingUnits.max` remains the hard ceiling. When `min + additionalPU` exceeds `max`, the lower bound is clamped down to `max` after the 1000-unit round-up, so the published range never inverts (`desiredMinPUs <= desiredMaxPUs` always holds). The trimmed contribution is surfaced with an Info log and a `ScheduleCappedAtMax` event, emitted once per range transition.

Implementation notes:

- The policy is carried on the `ActiveSchedule` status entry (copied by `Job.Run` at cron-fire time) because `calcDesiredPURange` only sees `status.currentlyActiveSchedules`.
- With multiple overlapping schedules, every schedule contributes to `desiredMinPUs`, while only `Exceed` schedules extend `desiredMaxPUs` — per-schedule intent is preserved instead of letting one `Cap` schedule cap the whole range.
- Adds a `Max PU Policy` printer column; README and CRD reference updated (including an explicit note that the default may exceed `spec.processingUnits.max`).
- The first commit is an unrelated generated-manifest catch-up for `SpannerManualScaling` (controller-tools v0.21.0 from #248 + godoc revised in #242); it also appears in #250 and will rebase away if that merges first.

## Backward compatibility

No behavior change unless `maxPUPolicy: Cap` is set. Empty/missing policy = `Exceed` on both the spec and status paths, so upgrade/rollback ordering between CRD and controller does not matter. On rollback, an old controller ignores the field and reverts to the exceed behavior.

## Testing

- Unit: `calcDesiredPURange` across Exceed/Cap/mixed schedules, min>max clamping, rounding-then-clamp order, empty-policy compatibility; `Job.Run` policy propagation.
- Emulator integration (`test/integration/schedule_maxpupolicy_test.go`): with `maxPUPolicy: Cap`, `additionalProcessingUnits: 20000`, `max: 60000`, and sustained CPU pressure of 120%, the instance holds at 60000 PU across repeated cron firings while `desiredMinPUs` reflects `min + additionalPU`. The default-policy path was re-verified to still scale to `max + additionalPU`.
- `gofmt` / `make generate` / `make manifests` / `make docs` clean; `golangci-lint` reports no issues in the changed packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)